### PR TITLE
feat: 마이페이지 - 내가 쓴 댓글 UI/UX

### DIFF
--- a/public/images/mypage/iconList.svg
+++ b/public/images/mypage/iconList.svg
@@ -1,0 +1,6 @@
+<svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M28 13.05L25.5 10.025L23 7V11.4C23 12.3113 23.7462 13.05 24.6667 13.05H28Z" fill="#EFEFEF"/>
+<path d="M28 14.7H24.6667C22.8257 14.7 21.3333 13.2225 21.3333 11.4V7H12.4444C9.98985 7 8 8.96995 8 11.4V24.6C8 27.0301 9.98985 29 12.4444 29H23.5556C26.0102 29 28 27.0301 28 24.6V14.7Z" fill="#EFEFEF"/>
+<rect x="12" y="18" width="12" height="2" rx="1" fill="white"/>
+<rect x="12" y="23" width="6" height="2" rx="1" fill="white"/>
+</svg>

--- a/src/app/mypage/admin/components/FilterContainer.tsx
+++ b/src/app/mypage/admin/components/FilterContainer.tsx
@@ -52,38 +52,40 @@ export default function FilterContainer({
             </TabButton>
           </TabWrapper>
         </div>
-        <div className='relative' ref={outRef}>
-          <button
-            className='flex items-center'
-            onClick={() => setDropdown((prev) => !prev)}
-          >
-            <p className='pr-1 max-[768px]:text-[12px]'>
-              {isSort === 'mostRecent'
-                ? '최신순'
-                : isSort === 'mostCommented'
-                ? '댓글순'
-                : '좋아요순'}
-            </p>
-            <Image
-              src='/images/arrowDown.svg'
-              alt='arrow_down'
-              width={24}
-              height={24}
-              className={
-                dropdown
-                  ? 'rotate-180 transition-transform duration-200'
-                  : 'transition-transform duration-200'
-              }
-            />
-          </button>
-          <DropdownContainer $active={dropdown}>
-            {dropdown && (
-              <DropdownBox>
-                <SortDropdown isSort={isSort} setIsSort={setIsSort} />
-              </DropdownBox>
-            )}
-          </DropdownContainer>
-        </div>
+        {selectedTab === 'post' && (
+          <div className='relative' ref={outRef}>
+            <button
+              className='flex items-center'
+              onClick={() => setDropdown((prev) => !prev)}
+            >
+              <p className='pr-1 max-[768px]:text-[12px]'>
+                {isSort === 'mostRecent'
+                  ? '최신순'
+                  : isSort === 'mostCommented'
+                  ? '댓글순'
+                  : '좋아요순'}
+              </p>
+              <Image
+                src='/images/arrowDown.svg'
+                alt='arrow_down'
+                width={24}
+                height={24}
+                className={
+                  dropdown
+                    ? 'rotate-180 transition-transform duration-200'
+                    : 'transition-transform duration-200'
+                }
+              />
+            </button>
+            <DropdownContainer $active={dropdown}>
+              {dropdown && (
+                <DropdownBox>
+                  <SortDropdown isSort={isSort} setIsSort={setIsSort} />
+                </DropdownBox>
+              )}
+            </DropdownContainer>
+          </div>
+        )}
       </div>
     </>
   );

--- a/src/app/mypage/admin/components/FilterContainer.tsx
+++ b/src/app/mypage/admin/components/FilterContainer.tsx
@@ -22,10 +22,12 @@ export default function FilterContainer({
 
   const handleTabClickPost = () => {
     setSelectedTab('post');
+    setIsSort('mostRecent');
   };
 
   const handleTabClickComment = () => {
     setSelectedTab('comment');
+    setIsSort('mostRecent');
   };
 
   return (

--- a/src/app/mypage/admin/components/ListContainer.tsx
+++ b/src/app/mypage/admin/components/ListContainer.tsx
@@ -33,20 +33,22 @@ export default function ListContainer({ selectedTab }: ListContainerProps) {
                 알바 추천해주세요
               </Title>
             </div>
-            <KebabButton ref={outRef}>
-              <Image
-                src='/images/kebabButton.svg'
-                alt='더보기'
-                width={36}
-                height={36}
-                className='cursor-pointer'
-                onClick={() => setDropdown((prev) => !prev)}
-              />
-              <PostDropdownContainer $active={dropdown}>
-                <PostDropwonButton type='button'>수정하기</PostDropwonButton>
-                <PostDropwonButton type='button'>삭제하기</PostDropwonButton>
-              </PostDropdownContainer>
-            </KebabButton>
+            {selectedTab === 'post' && (
+              <KebabButton ref={outRef}>
+                <Image
+                  src='/images/kebabButton.svg'
+                  alt='더보기'
+                  width={36}
+                  height={36}
+                  className='cursor-pointer'
+                  onClick={() => setDropdown((prev) => !prev)}
+                />
+                <PostDropdownContainer $active={dropdown}>
+                  <PostDropwonButton type='button'>수정하기</PostDropwonButton>
+                  <PostDropwonButton type='button'>삭제하기</PostDropwonButton>
+                </PostDropdownContainer>
+              </KebabButton>
+            )}
           </div>
           <Description comment={selectedTab === 'comment'}>
             알바 추천해주세요 알바 추천해주세요 알바 추천해주세요 알바

--- a/src/app/mypage/admin/components/ListContainer.tsx
+++ b/src/app/mypage/admin/components/ListContainer.tsx
@@ -6,18 +6,33 @@ import {
   KebabButton,
   PostDropdownContainer,
   PostDropwonButton,
+  Comment,
 } from '../../styles';
 import { useClickOutside } from '@/utils/useClickOutside';
+import { ListContainerProps } from '../../types';
 
-export default function ListContainer() {
+export default function ListContainer({ selectedTab }: ListContainerProps) {
   const { outRef, dropdown, setDropdown } = useClickOutside();
 
   return (
     <div className='flex flex-wrap gap-x-[2%] gap-y-[48px] max-[1199px]:gap-y-[16px]'>
       <PostWrapper>
         <div>
-          <div className='w-[100%] flex justify-between items-start'>
-            <Title>알바 추천해주세요</Title>
+          <div className='w-[100%] flex justify-between items-center'>
+            <div className='flex items-center'>
+              {selectedTab === 'comment' && (
+                <Image
+                  src='/images/mypage/iconList.svg'
+                  alt='Post'
+                  width={36}
+                  height={36}
+                  className=''
+                />
+              )}
+              <Title comment={selectedTab === 'comment'}>
+                알바 추천해주세요
+              </Title>
+            </div>
             <KebabButton ref={outRef}>
               <Image
                 src='/images/kebabButton.svg'
@@ -33,7 +48,7 @@ export default function ListContainer() {
               </PostDropdownContainer>
             </KebabButton>
           </div>
-          <Description>
+          <Description comment={selectedTab === 'comment'}>
             알바 추천해주세요 알바 추천해주세요 알바 추천해주세요 알바
             추천해주세요 알바 추천해주세요 알바 추천해주세요알바 추천해주세요
             알바 추천해주세요 알바 추천해주세요 알바 추천해주세요 알바
@@ -41,43 +56,59 @@ export default function ListContainer() {
             알바 추천해주세요 알바 추천해주세요 알바 추천해주세요 알바
           </Description>
         </div>
-        <div className='flex items-center justify-between text-gray-500 pt-[80px] max-[1199px]:pt-[24px] max-[768px]:pt-[40px] font-light'>
-          <div className='flex items-center'>
+        {selectedTab === 'post' ? (
+          <div className='flex items-center justify-between text-gray-500 pt-[80px] max-[1199px]:pt-[24px] max-[768px]:pt-[40px] font-light'>
             <div className='flex items-center'>
-              <Image
-                src='/images/defaultProfile.svg'
-                alt='기본프로필'
-                width={36}
-                height={36}
-                className='mr-[5px]'
-              />
-              김코드
+              <div className='flex items-center'>
+                <Image
+                  src='/images/defaultProfile.svg'
+                  alt='기본프로필'
+                  width={36}
+                  height={36}
+                  className='mr-[5px]'
+                />
+                김코드
+              </div>
+              <p className='pl-[16px] ml-[16px] border-l border-solid border-line-200 h-[18px] leading-[18px]'>
+                2024. 08. 06
+              </p>
             </div>
-            <p className='pl-[16px] ml-[16px] border-l border-solid border-line-200 h-[18px] leading-[18px]'>
+            <div className='flex items-center'>
+              <div className='flex items-center mr-[10px]'>
+                <Image
+                  src='/images/mypage/comment.svg'
+                  alt='댓글'
+                  width={36}
+                  height={36}
+                />
+                10
+              </div>
+              <div className='flex items-center'>
+                <Image
+                  src='/images/mypage/like.svg'
+                  alt='좋아요'
+                  width={36}
+                  height={36}
+                />
+                24
+              </div>
+            </div>
+          </div>
+        ) : selectedTab === 'comment' ? (
+          <div className='border-t border-solid border-line-100 mt-[15px] pt-[25px]'>
+            <Comment>
+              스터디카페 했었는데 너무 좋았어요스터디카페 했었는데 너무
+              좋았어요스터디카페 했었는데 너무 좋았어요스터디카페 했었는데 너무
+              좋았어요스터디카페 했었는데 너무 좋았어요스터디카페 했었는데 너무
+              좋았어요
+            </Comment>
+            <div className='text-[16px] mt-[16px] text-gray-500 font-light'>
               2024. 08. 06
-            </p>
-          </div>
-          <div className='flex items-center'>
-            <div className='flex items-center mr-[10px]'>
-              <Image
-                src='/images/mypage/comment.svg'
-                alt='댓글'
-                width={36}
-                height={36}
-              />
-              10
-            </div>
-            <div className='flex items-center'>
-              <Image
-                src='/images/mypage/like.svg'
-                alt='좋아요'
-                width={36}
-                height={36}
-              />
-              24
             </div>
           </div>
-        </div>
+        ) : (
+          ''
+        )}
       </PostWrapper>
     </div>
   );

--- a/src/app/mypage/admin/page.tsx
+++ b/src/app/mypage/admin/page.tsx
@@ -21,7 +21,7 @@ export default function mypage() {
         isSort={isSort}
         setIsSort={setIsSort}
       />
-      <ListContainer />
+      <ListContainer selectedTab={selectedTab}/>
     </ResponsiveStyle>
   );
 }

--- a/src/app/mypage/styles.ts
+++ b/src/app/mypage/styles.ts
@@ -25,15 +25,13 @@ type DropdownButtonProps = {
   $active?: boolean;
 };
 
-type PostDropdownProps = {
-  $active?: boolean;
-};
-
-type PostDropdownButtonProps = {
-  $active?: boolean;
+type TextProps = {
+  comment?: boolean;
 };
 
 export const KebabButton = styled.div`
+  min-width: 36px;
+  margin-top: -3px;
   position: relative;
   cursor: pointer;
 
@@ -208,19 +206,29 @@ export const PostWrapper = styled.div`
   }
 `;
 
-export const Title = styled.p`
-  padding-top: 4px;
+export const Title = styled.p.withConfig({
+  shouldForwardProp: (prop) => prop !== 'comment',
+})<TextProps>`
   text-overflow: ellipsis;
   overflow: hidden;
   word-break: break-word;
-  display: -webkit-box;
+  display: -webkit-inline-box;
   -webkit-line-clamp: 1;
   -webkit-box-orient: vertical;
   font-size: 18px;
   font-weight: 500;
+
+  ${({ comment }) =>
+    comment &&
+    css`
+      font-size: 16px;
+      color: var(--black100);
+    `}
 `;
 
-export const Description = styled.p`
+export const Description = styled.p.withConfig({
+  shouldForwardProp: (prop) => prop !== 'comment',
+})<TextProps>`
   width: 85%;
   margin-top: 10px;
   text-overflow: ellipsis;
@@ -231,6 +239,12 @@ export const Description = styled.p`
   -webkit-box-orient: vertical;
   font-weight: 300;
   color: var(--gray500);
+
+  ${({ comment }) =>
+    comment &&
+    css`
+      font-size: 14px;
+    `}
 `;
 
 export const PostDropdownContainer = styled.div<DropdownProps>`
@@ -266,4 +280,16 @@ export const PostDropwonButton = styled.button<DropdownButtonProps>`
   &:last-child {
     margin-bottom: 0;
   }
+`;
+
+export const Comment = styled.p`
+  width: 95%;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  word-break: break-word;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  font-size: 18px;
+  font-weight: 500;
 `;

--- a/src/app/mypage/types.ts
+++ b/src/app/mypage/types.ts
@@ -15,3 +15,7 @@ export interface SortDropdownProps {
     SetStateAction<'mostRecent' | 'mostCommented' | 'mostLiked'>
   >;
 }
+
+export interface ListContainerProps {
+  selectedTab: 'post' | 'comment';
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- Close #96 

## 📌 PR 내용 요약
- 마이페이지 - 내가 쓴 댓글 UIUX 추가

## ✨ 작업 내용
- 마이페이지 - 내가 쓴 글의 UIUX에 내가 쓴 댓글 UIUX 추가 구현 > 탭 클릭 시 UI 변동

## 🔍 테스트 방법 (선택)
![화면 기록 2025-05-03 오전 11 46 31](https://github.com/user-attachments/assets/ddb90de9-7e4b-4fa7-9bc1-162a0c2e6b56)

## ⚠️ 참고 및 공유 사항
- 같은 리스트 컴포넌트에서 탭 버튼의 조건에 따라 UI가 변동되도록 작업 됐습니다.
- 탭 버튼의 조건에 해당하는 코드에서 selectedTab === 'comment'와 같은 조건부는 true 또는 false를 반환하는 단순 boolean 값이지만, 이 값이 styled-components에서 만든 컴포넌트가 아니라 일반 DOM 태그로 전달되어 React는 HTML 속성으로 잘못 해석해서 경고를 출력하는 현상을 보였습니다. 따라서 해당 styled component에서는 shouldForwardProp을 사용하여 지정한 prop이 DOM에 전달되지 않도록 명시적으로 설정해두었습니다.
- (참고) 이전 마이페이지 - 내가 쓴 글 UI/UX에 해당하는 PR이 dev에 머지 되기 전이면 중복 커밋 diff가 함께 뜰 수 있습니다.