### PR TITLE
fix: 마이페이지 -  내가 작성한 글/스크랩 무한스크롤로 진행하기 위해 리액트 쿼리 구조 변경

### DIFF
--- a/src/app/mypage/admin/components/FilterContainer.tsx
+++ b/src/app/mypage/admin/components/FilterContainer.tsx
@@ -15,19 +15,19 @@ import { FilterContainerProps } from '../../types';
 export default function FilterContainer({
   selectedTab,
   setSelectedTab,
-  isSort,
-  setIsSort,
+  isPostSort,
+  setIsPostSort,
 }: FilterContainerProps) {
   const { outRef, dropdown, setDropdown } = useClickOutside();
 
   const handleTabClickPost = () => {
     setSelectedTab('post');
-    setIsSort('mostRecent');
+    setIsPostSort('mostRecent');
   };
 
   const handleTabClickComment = () => {
     setSelectedTab('comment');
-    setIsSort('mostRecent');
+    setIsPostSort('mostRecent');
   };
 
   return (
@@ -59,9 +59,9 @@ export default function FilterContainer({
               onClick={() => setDropdown((prev) => !prev)}
             >
               <p className='pr-1 max-[768px]:text-[12px]'>
-                {isSort === 'mostRecent'
+                {isPostSort === 'mostRecent'
                   ? '최신순'
-                  : isSort === 'mostCommented'
+                  : isPostSort === 'mostCommented'
                   ? '댓글순'
                   : '좋아요순'}
               </p>
@@ -80,7 +80,7 @@ export default function FilterContainer({
             <DropdownContainer $active={dropdown}>
               {dropdown && (
                 <DropdownBox>
-                  <SortDropdown isSort={isSort} setIsSort={setIsSort} />
+                  <SortDropdown isSort={isPostSort} setIsSort={setIsPostSort} />
                 </DropdownBox>
               )}
             </DropdownContainer>

--- a/src/app/mypage/admin/components/ListContainer.tsx
+++ b/src/app/mypage/admin/components/ListContainer.tsx
@@ -31,7 +31,7 @@ export default function ListContainer({
 
   return (
     <>
-      {listData?.length === 0 ? (
+      {!isLoading && listData?.length === 0 ? (
         <Empty selectedTab={selectedTab} />
       ) : (
         <div className='flex flex-wrap gap-x-[2%] gap-y-[48px] max-[1199px]:gap-y-[16px]'>

--- a/src/app/mypage/admin/page.tsx
+++ b/src/app/mypage/admin/page.tsx
@@ -13,8 +13,6 @@ export default function mypage() {
   const [isPostSort, setIsPostSort] = useState<
     'mostRecent' | 'mostCommented' | 'mostLiked'
   >('mostRecent');
-
-  // const { data:{result:listData} = {}, isLoading } = useGetMyContents(selectedTab, isSort);
   
   const query = useGetMyContents(selectedTab, isPostSort);
 

--- a/src/app/mypage/admin/page.tsx
+++ b/src/app/mypage/admin/page.tsx
@@ -6,14 +6,28 @@ import HeadContainer from './components/HeadContainer';
 import { useState } from 'react';
 import ListContainer from './components/ListContainer';
 import { useGetMyContents } from '@/hooks/query/useUser';
+import Pagination from './components/Pagination';
 
 export default function mypage() {
   const [selectedTab, setSelectedTab] = useState<'post' | 'comment'>('post');
-  const [isSort, setIsSort] = useState<
+  const [isPostSort, setIsPostSort] = useState<
     'mostRecent' | 'mostCommented' | 'mostLiked'
   >('mostRecent');
 
-  const { data: listData, isLoading } = useGetMyContents(selectedTab, isSort);
+  // const { data:{result:listData} = {}, isLoading } = useGetMyContents(selectedTab, isSort);
+  
+  const query = useGetMyContents(selectedTab, isPostSort);
+
+  let listData = [];
+  let isLoading = false;
+
+  if (query.type === 'comment') {
+    listData = query.data?.result ?? [];
+    isLoading = query.isLoading;
+  } else {
+    listData = query.data?.pages.flatMap((page) => page.result) ?? [];
+    isLoading = query.isLoading;
+  }
 
   return (
     <ResponsiveStyle>
@@ -21,10 +35,11 @@ export default function mypage() {
       <FilterContainer
         selectedTab={selectedTab}
         setSelectedTab={setSelectedTab}
-        isSort={isSort}
-        setIsSort={setIsSort}
+        isPostSort={isPostSort}
+        setIsPostSort={setIsPostSort}
       />
       <ListContainer selectedTab={selectedTab} listData={listData} isLoading={isLoading}/>
+      <Pagination />
     </ResponsiveStyle>
   );
 }

--- a/src/app/mypage/types.ts
+++ b/src/app/mypage/types.ts
@@ -3,8 +3,8 @@ import { SetStateAction } from 'react';
 export interface FilterContainerProps {
   selectedTab: 'post' | 'comment';
   setSelectedTab: React.Dispatch<SetStateAction<'post' | 'comment'>>;
-  isSort: 'mostRecent' | 'mostCommented' | 'mostLiked';
-  setIsSort: React.Dispatch<
+  isPostSort: 'mostRecent' | 'mostCommented' | 'mostLiked';
+  setIsPostSort: React.Dispatch<
     SetStateAction<'mostRecent' | 'mostCommented' | 'mostLiked'>
   >;
 }

--- a/src/hooks/query/useUser.ts
+++ b/src/hooks/query/useUser.ts
@@ -2,21 +2,39 @@
 // GET 'users/me'
 
 import { fetchMyComments, fetchMyPosts, fetchMyScrap } from '@/lib/fetch/user';
-import { useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
 
 // 내가 작성한 게시물/댓글/스크랩 목록 조회
 export const useGetMyContents = (
   selectedTab: 'post' | 'comment' | 'scrap',
-  isSort: 'mostRecent' | 'mostCommented' | 'mostLiked',
+  isPostSort: 'mostRecent' | 'mostCommented' | 'mostLiked',
+  isScrapSort?: 'mostRecent' | 'highestWage' | 'mostApplied' | 'mostScrapped',
 ) => {
-  return useQuery({
-    queryKey: ['post', selectedTab, isSort],
-    queryFn: () =>
-      selectedTab === 'post'
-        ? fetchMyPosts({ isSort })
-        : selectedTab === 'comment'
-        ? fetchMyComments()
-        : fetchMyScrap(),
+  const commentQuery = useQuery({
+    queryKey: ['myComments'],
+    queryFn: fetchMyComments,
     staleTime: 1000 * 60,
+    enabled: selectedTab === 'comment',
   });
+
+  const queryFn = ({pageParam = 1}) => selectedTab === 'post' ? fetchMyPosts({isPostSort, cursor:pageParam}) : fetchMyScrap({isScrapSort, cursor:pageParam})
+  
+  const postOrScrapQuery = useInfiniteQuery({
+    queryKey: [
+      selectedTab === 'post' ? 'myPosts' : 'myScrap',
+      selectedTab === 'post' ? isPostSort : isScrapSort,
+    ],
+    queryFn,
+    getNextPageParam: (lastPage) => lastPage?.nextCursor ?? null,
+    initialPageParam: 1,
+    staleTime: 1000 * 60,
+    enabled: selectedTab !== 'comment',
+  });
+
+  if (selectedTab === 'comment') {
+    return { type: 'comment' as const, ...commentQuery };
+  } else {
+    return { type: selectedTab, ...postOrScrapQuery };
+  }
+
 };

--- a/src/lib/fetch/user.ts
+++ b/src/lib/fetch/user.ts
@@ -76,9 +76,12 @@ export const fetchMyAppications = async () => {
 };
 
 // 내가 스크랩한 알바폼 목록 조회
-export const fetchMyScrap = async () => {
+export const fetchMyScrap = async ({
+  isScrapSort,
+  cursor
+}:{isScrapSort?:'mostRecent' | 'highestWage' | 'mostApplied' | 'mostScrapped'; cursor:number}) => {
   try {
-    const response = await instance.get('/users/me/scraps');
+    const response = await instance.get(`/users/me/scraps?limit=6&orderBy=${isScrapSort}`);
     if (!response.data) {
       throw new Error('내 스크랩 데이터 불러오기 실패');
     }
@@ -92,19 +95,21 @@ export const fetchMyScrap = async () => {
 
 // 내가 작성한 게시물 목록 조회
 export const fetchMyPosts = async ({
-  isSort,
+  isPostSort,
+  cursor
 }: {
-  isSort: 'mostRecent' | 'mostCommented' | 'mostLiked';
+  isPostSort: 'mostRecent' | 'mostCommented' | 'mostLiked';
+  cursor:number
 }) => {
   try {
     const response = await instance.get(
-      `/users/me/posts?limit=6&orderBy=${isSort}`,
+      `/users/me/posts?limit=6&orderBy=${isPostSort}`,
     );
     if (!response.data) {
       throw new Error('내 게시물 데이터 불러오기 실패');
     }
     const result = response.data.data;
-    return result;
+    return {result};
   } catch (error) {
     console.error('내 게시물 데이터 불러오는 중 에러 발생:', error);
     throw error;
@@ -119,7 +124,7 @@ export const fetchMyComments = async () => {
       throw new Error('내 댓글 데이터 불러오기 실패');
     }
     const result = response.data.data;
-    return result;
+    return {result};
   } catch (error) {
     console.error('내 댓글 데이터 불러오는 중 에러 발생:', error);
     throw error;

--- a/src/utils/calcPagination.ts
+++ b/src/utils/calcPagination.ts
@@ -1,0 +1,28 @@
+interface PaginationProps {
+    page: number;
+    totalItemCount: number;
+    itemsPerPage: number;
+    pageDisplayCount: number;
+  }
+  
+  function calcPagination({
+    page, //현재 페이지
+    totalItemCount, //전체 데이터수
+    itemsPerPage, //한 페이지당 데이터 수
+    pageDisplayCount, //한번에 보여줄 페이지네이션 수
+  }: PaginationProps) {
+    const totalPages = Math.ceil(totalItemCount / itemsPerPage);
+    const currentSet = Math.ceil(page / pageDisplayCount);
+    const startPage = (currentSet - 1) * pageDisplayCount + 1;
+    const endPage = Math.min(startPage + pageDisplayCount - 1, totalPages);
+  
+    return {
+      totalPages,
+      currentSet,
+      startPage,
+      endPage,
+      hasPrev: startPage > 1,
+      hasNext: endPage < totalPages,
+    };
+  }
+  


### PR DESCRIPTION
## 🔗 관련 이슈
- Close #X

## 📌 PR 내용 요약
- 백엔드에서 요구하는 스웨거 엔드포인트와 제공되는 리스폰스 값이 피그마 디자인의 페이지네이션을 구현하기에 무리가 있어 마이페이지의 내가 작성한 글 및 사용자의 내가 스크랩한 글에 관련된 페이지를 무한스크롤로 변경. 그에 따른 기존 리액트 쿼리 코드 구조를 수정했음

## ✨ 작업 내용
- 페이지네이션 유틸리티성 함수 추가
- 기존 마이페이지의 API를 호출하고 데이터를 받아오는 코드를 일부 조건에서 무한스크롤로 진행할 수 있도록 추가 변경

## 🔍 테스트 방법 (선택)

## ⚠️ 참고 및 공유 사항
- 마이페이지 - 내가쓴글/스크랩은 무한스크롤로 구현되며, 내가 쓴 댓글은 페이지네이션으로 구현될 예정이므로 React Query 내부 구조를 분리하여 관리하도록 했습니다.
- 마이페이지 - 스크랩은 '사용자' 권한에서만 사용될 페이지지만 통합 React query를 사용하기에 추후 작업을 위해 API 구조를 함께 세팅해두었습니다.
