### PR TITLE
feat: 카카오 주소 검색 API x,y 좌표 추출 및 지도 마커 출력 구현/테스트 완료

### DIFF
--- a/src/components/common/StoreMap.tsx
+++ b/src/components/common/StoreMap.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { useRef } from 'react';
+import { useKakaoMap } from '@/hooks/common/useKakaoMap';
+
+export default function StoreMap({ address }: { address: string }) {
+  const mapRef = useRef<HTMLDivElement | null>(null);
+
+  useKakaoMap(mapRef, address);
+
+  return (
+    <>
+      <div
+        ref={mapRef}
+        // CSS는 임시이므로 디자인에 맞춰 수정 필요
+        className='w-full h-[300px] rounded-md border border-gray-300'
+      />
+    </>
+  );
+}

--- a/src/hooks/common/useKakaoMap.ts
+++ b/src/hooks/common/useKakaoMap.ts
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react';
+import { getCoordsByAddress } from '@/utils/getCoordsByAddress';
+
+declare global {
+  interface Window {
+    kakao: any;
+  }
+}
+
+export const useKakaoMap = (
+  mapRef: React.RefObject<HTMLDivElement | null>,
+  address: string,
+) => {
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (!address || !mapRef.current) return;
+
+    getCoordsByAddress(address)
+      .then(({ x, y }) => {
+        if (!window.kakao) return;
+
+        const map = new window.kakao.maps.Map(mapRef.current, {
+          center: new window.kakao.maps.LatLng(y, x),
+          level: 3,
+        });
+
+        new window.kakao.maps.Marker({
+          map,
+          position: new window.kakao.maps.LatLng(y, x),
+        });
+      })
+      .catch((err) => {
+        console.error(err);
+        setError('지도 로딩 실패');
+      });
+  }, [address]);
+
+  return { error };
+};

--- a/src/utils/getCoordsByAddress.ts
+++ b/src/utils/getCoordsByAddress.ts
@@ -6,9 +6,15 @@ type KakaoAddressSearchResult = {
 
 type KakaoStatus = 'OK' | 'ZERO_RESULT' | 'ERROR';
 
+const addressCache = new Map<string, { x: number; y: number }>();
+
 export const getCoordsByAddress = (
   address: string,
 ): Promise<{ x: number; y: number }> => {
+  if (addressCache.has(address)) {
+    return Promise.resolve(addressCache.get(address)!);
+  }
+
   return new Promise((resolve, reject) => {
     if (typeof window === 'undefined') return reject('No Client');
 
@@ -16,22 +22,22 @@ export const getCoordsByAddress = (
       return reject('Kakao 지도 API가 완전히 로드되지 않았습니다.');
     }
 
-    if (window.kakao && window.kakao.maps) {
-      window.kakao.maps.load(function () {
-        const geocoder = new window.kakao.maps.services.Geocoder();
+    window.kakao.maps.load(() => {
+      const geocoder = new window.kakao.maps.services.Geocoder();
 
-        geocoder.addressSearch(
-          address,
-          (result: KakaoAddressSearchResult[], status: KakaoStatus) => {
-            if (status === window.kakao.maps.services.Status.OK) {
-              const { x, y } = result[0];
-              resolve({ x: parseFloat(x), y: parseFloat(y) });
-            } else {
-              reject(`좌표 변환 실패 - 상태: ${status}`);
-            }
-          },
-        );
-      });
-    }
+      geocoder.addressSearch(
+        address,
+        (result: KakaoAddressSearchResult[], status: KakaoStatus) => {
+          if (status === window.kakao.maps.services.Status.OK) {
+            const { x, y } = result[0];
+            const parsed = { x: parseFloat(x), y: parseFloat(y) };
+            addressCache.set(address, parsed);
+            resolve(parsed);
+          } else {
+            reject(`좌표 변환 실패 - 상태: ${status}`);
+          }
+        },
+      );
+    });
   });
 };


### PR DESCRIPTION
## 🔗 관련 이슈
- Close #56 

## 📌 PR 내용 요약
- 카카오맵 x,y 좌표 추출 및 마커 출력

## ✨ 작업 내용
- getCoordsByAddress.ts에서 주소값에 해당하는 x,y 좌표를 캐시에 저장하여 즉시 반환하고 카카오 지도에 마커를 출력하는 방식으로 수정
- getCoordsByAddress.ts에서 반환 된 x,y 좌표를 useKakaoMap에서 mapRef로 전달, mapRef가 지정된 태그가 지도 내 마커로 출력되도록 구현

## 🔍 테스트 방법 (선택)
<img width="1182" alt="2025-05-17_2 54 50" src="https://github.com/user-attachments/assets/fe7942aa-2246-43f3-9a38-235ca66b1d7f" />
** '내 정보 수정' 모달에서 임의로 테스트 진행

## ⚠️ 참고 및 공유 사항
@mynameishwan @yeon0036 
address RHF Controller 사용해서 카카오맵 > 주소 선택 >  주소값 API 전송 => 이거만 해주시면 됩니다. *Controller에서 control={} 부분 작업 상황에 맞게 조건부로 적용 해주세요.

@katej0320 
StoreMap.tsx 컴포넌트를 Import 하고 API에서 받아온 주소 데이터를 address 프롭으로 넘겨주세요.