### PR TITLE
fix: 비밀번호 '변경하기' 버튼 활성화 조건 수정

### DIFF
--- a/src/app/mypage/components/modal/EditPassword/EditPasswordForm.tsx
+++ b/src/app/mypage/components/modal/EditPassword/EditPasswordForm.tsx
@@ -7,7 +7,7 @@ export default function EditPasswordForm(props: EditPasswordFormProps) {
   const { form, onSubmit, isPending, handleCloseModal } = props;
 
   const { handleSubmit, register, formState } = form;
-  const { errors } = formState;
+  const { isValid, errors } = formState;
 
   const [visibleFields, setVisibleFields] = useState({
     current: false,
@@ -25,7 +25,7 @@ export default function EditPasswordForm(props: EditPasswordFormProps) {
   const { watch } = form;
   const watched = watch();
 
-  const { isModified } = usePasswordChangeDetector(watched);
+  const { isModified } = usePasswordChangeDetector(watched, errors);
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
@@ -158,7 +158,7 @@ export default function EditPasswordForm(props: EditPasswordFormProps) {
           <button
             type='submit'
             className='flex-[1] pt-[20px] pb-[20px] text-white bg-primary-orange300 rounded-[8px] disabled:bg-gray-400 disabled:cursor-not-allowed'
-            disabled={!isModified || isPending}
+            disabled={!isValid || !isModified || isPending}
           >
             변경하기
           </button>

--- a/src/app/mypage/components/modal/EditPassword/EditPasswordModal.tsx
+++ b/src/app/mypage/components/modal/EditPassword/EditPasswordModal.tsx
@@ -1,5 +1,4 @@
 import Image from 'next/image';
-import useFormChangeDetector from '@/app/mypage/hooks/usePasswordChangeDetector';
 import { ScrollHiddenDiv } from '@/app/mypage/styles';
 import { EditModalProps } from '@/app/mypage/types';
 import Overlay from '@/components/modal/Overlay';

--- a/src/app/mypage/hooks/usePasswordChangeDetector.ts
+++ b/src/app/mypage/hooks/usePasswordChangeDetector.ts
@@ -1,14 +1,24 @@
+import { FieldErrors } from 'react-hook-form';
 import { PasswordWatchedFields } from '../types';
 
 export default function usePasswordChangeDetector(
   watched: PasswordWatchedFields,
+  errors: FieldErrors<PasswordWatchedFields> = {},
 ) {
+  const hasError =
+    !!errors.currentPassword ||
+    !!errors.newPassword ||
+    !!errors.confirmPassword;
+
   const isModified = Boolean(
-    watched.newPassword &&
-      watched.confirmPassword &&
+    watched.currentPassword !== '' &&
+      watched.newPassword !== '' &&
+      watched.confirmPassword !== '' &&
       watched.newPassword === watched.confirmPassword &&
-      watched.currentPassword !== '',
+      !hasError,
   );
+
+  console.log(watched, errors);
 
   return { isModified };
 }


### PR DESCRIPTION
## 🔗 관련 이슈
- Close #X

## 📌 PR 내용 요약
- schema 에러가 발생함에도 input 입력값이 모두 존재할 경우 '변경하기' 버튼이 활성화 되는 버그가 발견되어 조건을 강화했습니다.
- useForm에서 받은 errors의 에러 메세지 존재 여부를 조건에 추가하여 '변경하기' 버튼 활성화 버그를 수정했습니다.

## ✨ 작업 내용
- (기존)
  watched.currentPassword !== '' &&
  watched.newPassword !== '' &&
  watched.confirmPassword !== '' &&
  watched.newPassword === watched.confirmPassword
  
- (변경후)
  const hasError =
    !!errors.currentPassword ||
    !!errors.newPassword ||
    !!errors.confirmPassword;

  const isModified = Boolean(
    watched.currentPassword !== '' &&
      watched.newPassword !== '' &&
      watched.confirmPassword !== '' &&
      watched.newPassword === watched.confirmPassword &&
      !hasError,
  );

## 🔍 테스트 방법 (선택)

## ⚠️ 참고 및 공유 사항
