### PR TITLE
feat: 알바토크 리스트 API 연동 및 데이터 출력 + 무한스크롤 구현

### DIFF
--- a/src/app/albatalk/components/ContentsList.tsx
+++ b/src/app/albatalk/components/ContentsList.tsx
@@ -4,6 +4,7 @@ import { ListContainerProps } from '../types';
 import { formattedDate } from '@/utils/formattedDate';
 import { useState } from 'react';
 import Loader from '@/components/loader/Loader';
+import Empty from '@/components/empty/Empty';
 
 export default function ContentsList({
   listData,
@@ -18,65 +19,69 @@ export default function ContentsList({
   };
   return (
     <>
-      <div className='min-lg:min-h-[500px]'>
-        <div className='flex flex-wrap gap-x-[2%] gap-y-[48px] max-lg:gap-y-[16px]'>
-          {(isLoading || isFetchingNextPage) && <Loader />}
-          {listData.map((item) => {
-            const { writer } = item;
+      {!isLoading && listData?.length === 0 ? (
+        <Empty albatalk/>
+      ) : (
+        <div className='min-lg:min-h-[500px]'>
+          <div className='flex flex-wrap gap-x-[2%] gap-y-[48px] max-lg:gap-y-[16px]'>
+            {(isLoading || isFetchingNextPage) && <Loader />}
+            {listData.map((item) => {
+              const { writer } = item;
 
-            return (
-              <PostWrapper key={item.id}>
-                <Title>{item.title}</Title>
-                <Description>{item.content}</Description>
-                <div className='flex items-center justify-between text-gray-500 pt-[80px] max-lg:pt-[24px] max-md:pt-[40px] font-light'>
-                  <div className='flex items-center'>
+              return (
+                <PostWrapper key={item.id}>
+                  <Title>{item.title}</Title>
+                  <Description>{item.content}</Description>
+                  <div className='flex items-center justify-between text-gray-500 pt-[80px] max-lg:pt-[24px] max-md:pt-[40px] font-light'>
                     <div className='flex items-center'>
-                      <Image
-                        src={
-                          profileImg[String(writer?.imageUrl)] ||
-                          writer?.imageUrl ||
-                          defaultProfileImg
-                        }
-                        alt='기본프로필'
-                        width={26}
-                        height={26}
-                        className='mr-[5px] rounded-[50%] object-cover border border-gray500 min-h-[26px]'
-                        onError={() =>
-                          handleProfileImgError(String(writer?.imageUrl))
-                        }
-                      />
-                      <p className='max-xs:text-[14px]'>{writer?.nickname}</p>
-                    </div>
-                    <p className='pl-[16px] ml-[16px] border-l border-solid border-line-200 h-[18px] leading-[18px] max-xs:text-[14px] max-xs:pl-[12px] max-xs:ml-[12px]'>
-                      {formattedDate(item.createdAt)}
-                    </p>
-                  </div>
-                  <div className='flex items-center'>
-                    <div className='flex items-center mr-[10px]'>
-                      <Image
-                        src='/images/mypage/comment.svg'
-                        alt='댓글'
-                        width={36}
-                        height={36}
-                      />
-                      {item.commentCount}
+                      <div className='flex items-center'>
+                        <Image
+                          src={
+                            profileImg[String(writer?.imageUrl)] ||
+                            writer?.imageUrl ||
+                            defaultProfileImg
+                          }
+                          alt='기본프로필'
+                          width={26}
+                          height={26}
+                          className='mr-[5px] rounded-[50%] object-cover border border-gray500 min-h-[26px]'
+                          onError={() =>
+                            handleProfileImgError(String(writer?.imageUrl))
+                          }
+                        />
+                        <p className='max-xs:text-[14px]'>{writer?.nickname}</p>
+                      </div>
+                      <p className='pl-[16px] ml-[16px] border-l border-solid border-line-200 h-[18px] leading-[18px] max-xs:text-[14px] max-xs:pl-[12px] max-xs:ml-[12px]'>
+                        {formattedDate(item.createdAt)}
+                      </p>
                     </div>
                     <div className='flex items-center'>
-                      <Image
-                        src='/images/mypage/like.svg'
-                        alt='좋아요'
-                        width={36}
-                        height={36}
-                      />
-                      {item.likeCount}
+                      <div className='flex items-center mr-[10px]'>
+                        <Image
+                          src='/images/mypage/comment.svg'
+                          alt='댓글'
+                          width={36}
+                          height={36}
+                        />
+                        {item.commentCount}
+                      </div>
+                      <div className='flex items-center'>
+                        <Image
+                          src='/images/mypage/like.svg'
+                          alt='좋아요'
+                          width={36}
+                          height={36}
+                        />
+                        {item.likeCount}
+                      </div>
                     </div>
                   </div>
-                </div>
-              </PostWrapper>
-            );
-          })}
+                </PostWrapper>
+              );
+            })}
+          </div>
         </div>
-      </div>
+      )}
     </>
   );
 }

--- a/src/app/albatalk/components/ContentsList.tsx
+++ b/src/app/albatalk/components/ContentsList.tsx
@@ -1,56 +1,80 @@
 import Image from 'next/image';
 import { Description, PostWrapper, Title } from '../styles';
+import { ListContainerProps } from '../types';
+import { formattedDate } from '@/utils/formattedDate';
+import { useState } from 'react';
+import Loader from '@/components/loader/Loader';
 
-export default function ContentsList() {
+export default function ContentsList({
+  listData,
+  isLoading,
+  isFetchingNextPage,
+}: ListContainerProps) {
+  const [profileImg, setProfileImg] = useState<Record<string, string>>({});
+
+  const defaultProfileImg = '/images/defaultProfile.svg';
+  const handleProfileImgError = (src: string) => {
+    setProfileImg((prev) => ({ ...prev, [src]: defaultProfileImg }));
+  };
   return (
     <>
       <div className='min-lg:min-h-[500px]'>
         <div className='flex flex-wrap gap-x-[2%] gap-y-[48px] max-lg:gap-y-[16px]'>
-          <PostWrapper>
-            <Title>
-              제목입니다제목입니다제목입니다제목입니다제목입니다제목입니다제목입니다제목입니다제목입니다제목입니다제목입니다
-            </Title>
-            <Description>
-              설명입니다설명입니다설명입니다설명입니다설명입니다설명입니다설명입니다설명입니다설명입니다설명입니다설명입니다설명입니다설명입니다설명입니다설명입니다설명입니다설명입니다설명입니다설명입니다설명입니다설명입니다설명입니다설명입니다설명입니다설명입니다설명입니다
-            </Description>
-            <div className='flex items-center justify-between text-gray-500 pt-[80px] max-lg:pt-[24px] max-md:pt-[40px] font-light'>
-              <div className='flex items-center'>
-                <div className='flex items-center'>
-                  <Image
-                    src='/images/defaultProfile.svg'
-                    alt='기본프로필'
-                    width={26}
-                    height={26}
-                    className='mr-[5px] rounded-[50%] object-cover border border-gray500 min-h-[26px]'
-                  />
-                  <p className='max-xs:text-[14px]'>닉네임</p>
+          {(isLoading || isFetchingNextPage) && <Loader />}
+          {listData.map((item) => {
+            const { writer } = item;
+
+            return (
+              <PostWrapper key={item.id}>
+                <Title>{item.title}</Title>
+                <Description>{item.content}</Description>
+                <div className='flex items-center justify-between text-gray-500 pt-[80px] max-lg:pt-[24px] max-md:pt-[40px] font-light'>
+                  <div className='flex items-center'>
+                    <div className='flex items-center'>
+                      <Image
+                        src={
+                          profileImg[String(writer?.imageUrl)] ||
+                          writer?.imageUrl ||
+                          defaultProfileImg
+                        }
+                        alt='기본프로필'
+                        width={26}
+                        height={26}
+                        className='mr-[5px] rounded-[50%] object-cover border border-gray500 min-h-[26px]'
+                        onError={() =>
+                          handleProfileImgError(String(writer?.imageUrl))
+                        }
+                      />
+                      <p className='max-xs:text-[14px]'>{writer?.nickname}</p>
+                    </div>
+                    <p className='pl-[16px] ml-[16px] border-l border-solid border-line-200 h-[18px] leading-[18px] max-xs:text-[14px] max-xs:pl-[12px] max-xs:ml-[12px]'>
+                      {formattedDate(item.createdAt)}
+                    </p>
+                  </div>
+                  <div className='flex items-center'>
+                    <div className='flex items-center mr-[10px]'>
+                      <Image
+                        src='/images/mypage/comment.svg'
+                        alt='댓글'
+                        width={36}
+                        height={36}
+                      />
+                      {item.commentCount}
+                    </div>
+                    <div className='flex items-center'>
+                      <Image
+                        src='/images/mypage/like.svg'
+                        alt='좋아요'
+                        width={36}
+                        height={36}
+                      />
+                      {item.likeCount}
+                    </div>
+                  </div>
                 </div>
-                <p className='pl-[16px] ml-[16px] border-l border-solid border-line-200 h-[18px] leading-[18px] max-xs:text-[14px] max-xs:pl-[12px] max-xs:ml-[12px]'>
-                  2020. 02. 02
-                </p>
-              </div>
-              <div className='flex items-center'>
-                <div className='flex items-center mr-[10px]'>
-                  <Image
-                    src='/images/mypage/comment.svg'
-                    alt='댓글'
-                    width={36}
-                    height={36}
-                  />
-                  10
-                </div>
-                <div className='flex items-center'>
-                  <Image
-                    src='/images/mypage/like.svg'
-                    alt='좋아요'
-                    width={36}
-                    height={36}
-                  />
-                  10
-                </div>
-              </div>
-            </div>
-          </PostWrapper>
+              </PostWrapper>
+            );
+          })}
         </div>
       </div>
     </>

--- a/src/app/albatalk/components/FilterContainer.tsx
+++ b/src/app/albatalk/components/FilterContainer.tsx
@@ -1,14 +1,25 @@
 import Image from 'next/image';
 import { FilterContainerProps } from '../types';
 import PostSortButton from '@/components/postSort/PostSortButton';
+import React from 'react';
 
 export default function FilterContainer({
   isSort,
   setIsSort,
+  setIsKeyword,
 }: FilterContainerProps) {
+  const handleEnterSearch = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    const formData = new FormData(e.currentTarget);
+    const keyword = formData.get('search') as string;
+
+    setIsKeyword(keyword);
+  };
+
   return (
     <div className='flex justify-between items-center max-xs:flex-col max-xs:items-stretch'>
-      <form className='flex-[1]'>
+      <form onSubmit={handleEnterSearch} className='flex-[1]'>
         <div className='flex bg-background-200 rounded-[24px] px-[24px] py-[14px] max-md:px-[14px] max-xs:mb-[16px]'>
           <Image
             src='/images/iconSearch.svg'
@@ -17,6 +28,7 @@ export default function FilterContainer({
             height={36}
           />
           <input
+            name='search'
             type='text'
             placeholder='궁금한 점을 검색해보세요'
             className='ml-[8px] bg-background-200 text-[20px] w-full max-md:text-[16px] max-md:ml-[2px]'

--- a/src/app/albatalk/page.tsx
+++ b/src/app/albatalk/page.tsx
@@ -5,11 +5,27 @@ import { useState } from 'react';
 import { FilterResponsive, ListResponsive } from './styles';
 import ContentsList from './components/ContentsList';
 import FloatingButton from './components/FloatingButton';
+import { getItemsPerPage } from './utils/getItemsPerPage';
+import { useGetPosts } from '@/hooks/query/useGetPosts';
+import { useInfiniteScroll } from '@/hooks/common/useInfiniteScroll';
 
 export default function AlbaTalk() {
   const [isSort, setIsSort] = useState<
     'mostRecent' | 'mostCommented' | 'mostLiked'
   >('mostRecent');
+
+  const itemsPerPage = getItemsPerPage();
+  const {
+    data: postsData,
+    hasNextPage,
+    fetchNextPage,
+    isLoading,
+    isFetchingNextPage,
+  } = useGetPosts(itemsPerPage, isSort);
+
+  const listData = postsData?.pages.flatMap((page) => page.result) ?? [];
+
+  const observerRef = useInfiniteScroll(isSort && hasNextPage!, fetchNextPage!);
 
   return (
     <>
@@ -19,9 +35,14 @@ export default function AlbaTalk() {
         </FilterResponsive>
       </div>
       <ListResponsive>
-        <ContentsList />
+        <ContentsList
+          listData={listData}
+          isLoading={isLoading}
+          isFetchingNextPage={isFetchingNextPage}
+        />
       </ListResponsive>
       <FloatingButton />
+      {hasNextPage && <div ref={observerRef} style={{ height: '1px' }} />}
     </>
   );
 }

--- a/src/app/albatalk/page.tsx
+++ b/src/app/albatalk/page.tsx
@@ -13,15 +13,17 @@ export default function AlbaTalk() {
   const [isSort, setIsSort] = useState<
     'mostRecent' | 'mostCommented' | 'mostLiked'
   >('mostRecent');
+  const [isKeyword, setIsKeyword] = useState('');
 
   const itemsPerPage = getItemsPerPage();
+
   const {
     data: postsData,
     hasNextPage,
     fetchNextPage,
     isLoading,
     isFetchingNextPage,
-  } = useGetPosts(itemsPerPage, isSort);
+  } = useGetPosts(itemsPerPage, isSort, isKeyword);
 
   const listData = postsData?.pages.flatMap((page) => page.result) ?? [];
 
@@ -31,7 +33,7 @@ export default function AlbaTalk() {
     <>
       <div className='border-solid border-b-[1px] border-line-100 max-xs:border-b-[0px]'>
         <FilterResponsive>
-          <FilterContainer isSort={isSort} setIsSort={setIsSort} />
+          <FilterContainer isSort={isSort} setIsSort={setIsSort} setIsKeyword={setIsKeyword}/>
         </FilterResponsive>
       </div>
       <ListResponsive>

--- a/src/app/albatalk/types.ts
+++ b/src/app/albatalk/types.ts
@@ -1,8 +1,38 @@
-import { SetStateAction } from "react";
+import { SetStateAction } from 'react';
 
 export interface FilterContainerProps {
   isSort: 'mostRecent' | 'mostCommented' | 'mostLiked';
   setIsSort: React.Dispatch<
     SetStateAction<'mostRecent' | 'mostCommented' | 'mostLiked'>
   >;
+}
+
+type WriterData = {
+  id: number;
+  imageUrl?: string;
+  nickname: string;
+};
+
+type PostData = {
+  id: number;
+  title: string;
+  content: string;
+};
+
+export interface ListData {
+  id: number;
+  imageUrl?: string;
+  title?: string;
+  content: string;
+  createdAt: string;
+  updatedAt: string;
+  commentCount?: number;
+  likeCount?: number;
+  writer?: WriterData;
+}
+
+export interface ListContainerProps {
+  listData: ListData[];
+  isLoading: boolean;
+  isFetchingNextPage: boolean;
 }

--- a/src/app/albatalk/types.ts
+++ b/src/app/albatalk/types.ts
@@ -1,10 +1,11 @@
-import { SetStateAction } from 'react';
+import { Dispatch, SetStateAction } from 'react';
 
 export interface FilterContainerProps {
   isSort: 'mostRecent' | 'mostCommented' | 'mostLiked';
   setIsSort: React.Dispatch<
     SetStateAction<'mostRecent' | 'mostCommented' | 'mostLiked'>
   >;
+  setIsKeyword: Dispatch<SetStateAction<string>>;
 }
 
 type WriterData = {

--- a/src/app/albatalk/utils/getItemsPerPage.ts
+++ b/src/app/albatalk/utils/getItemsPerPage.ts
@@ -1,0 +1,15 @@
+export const getItemsPerPage = () => {
+  if (typeof window === 'undefined') {
+    return 12;
+  }
+
+  const width = window.innerWidth;
+  const height = window.innerHeight;
+  if (height < 830) {
+    if (width >= 1200 && width <= 1450) {
+      return 8;
+    }
+    return 9;
+  }
+  return 12;
+};

--- a/src/components/empty/Empty.tsx
+++ b/src/components/empty/Empty.tsx
@@ -2,7 +2,7 @@ import Image from 'next/image';
 import { EmptyContainer } from './Empty.styles';
 import { EmptyProps } from './Empty.types';
 
-export default function Empty({ selectedTab, albaform }: EmptyProps) {
+export default function Empty({ selectedTab, albaform, albatalk }: EmptyProps) {
   const tabPostText = () => {
     return (
       <>
@@ -27,8 +27,19 @@ export default function Empty({ selectedTab, albaform }: EmptyProps) {
     );
   };
 
+  const albatalkText = () => {
+    return (
+      <>
+        등록된 알바토크가 없어요.
+        <br />
+        궁금한 점이 있다면 먼저 게시글을 작성해보세요!
+      </>
+    );
+  };
+
   const renderContent = () => {
     if (albaform) return albaformText();
+    if (albatalk) return albatalkText();
     if (selectedTab === 'post') return tabPostText();
     if (selectedTab === 'comment') return tabCommentText();
   };

--- a/src/components/empty/Empty.types.ts
+++ b/src/components/empty/Empty.types.ts
@@ -1,4 +1,5 @@
 export interface EmptyProps {
   selectedTab?: 'post' | 'comment';
   albaform?: boolean;
+  albatalk?: boolean;
 }

--- a/src/components/loader/Loader.styles.ts
+++ b/src/components/loader/Loader.styles.ts
@@ -22,5 +22,5 @@ export const LoaderContainer = styled.div`
   position: fixed;
   left: 50%;
   top: 50%;
-  transform: (-50%, -50%);
+  transform: translate(-50%, -50%);
 `;

--- a/src/hooks/query/useGetPosts.ts
+++ b/src/hooks/query/useGetPosts.ts
@@ -7,11 +7,12 @@ import { useInfiniteQuery } from '@tanstack/react-query';
 export const useGetPosts = (
   itemsPerPage: number,
   isSort: 'mostRecent' | 'mostCommented' | 'mostLiked',
+  isKeyword:string
 ) => {
   return useInfiniteQuery({
-    queryKey: ['posts', isSort],
+    queryKey: ['posts', isSort, isKeyword],
     queryFn: ({ pageParam = 1 }) =>
-      fetchGetPosts({ isSort, itemsPerPage, cursor: pageParam }),
+      fetchGetPosts({ isSort, itemsPerPage, cursor: pageParam, isKeyword }),
     getNextPageParam: (lastPage) => lastPage?.nextPage ?? undefined,
     initialPageParam: 1,
     staleTime: 1000 * 60,

--- a/src/hooks/query/useGetPosts.ts
+++ b/src/hooks/query/useGetPosts.ts
@@ -1,2 +1,19 @@
 // 게시글 불러오기
 // GET '/posts'
+
+import { fetchGetPosts } from '@/lib/fetch/post';
+import { useInfiniteQuery } from '@tanstack/react-query';
+
+export const useGetPosts = (
+  itemsPerPage: number,
+  isSort: 'mostRecent' | 'mostCommented' | 'mostLiked',
+) => {
+  return useInfiniteQuery({
+    queryKey: ['posts'],
+    queryFn: ({ pageParam = 1 }) =>
+      fetchGetPosts({ isSort, itemsPerPage, cursor: pageParam }),
+    getNextPageParam: (lastPage) => lastPage?.nextPage ?? undefined,
+    initialPageParam: 1,
+    staleTime: 1000 * 60,
+  });
+};

--- a/src/hooks/query/useGetPosts.ts
+++ b/src/hooks/query/useGetPosts.ts
@@ -9,7 +9,7 @@ export const useGetPosts = (
   isSort: 'mostRecent' | 'mostCommented' | 'mostLiked',
 ) => {
   return useInfiniteQuery({
-    queryKey: ['posts'],
+    queryKey: ['posts', isSort],
     queryFn: ({ pageParam = 1 }) =>
       fetchGetPosts({ isSort, itemsPerPage, cursor: pageParam }),
     getNextPageParam: (lastPage) => lastPage?.nextPage ?? undefined,

--- a/src/lib/fetch/post.ts
+++ b/src/lib/fetch/post.ts
@@ -20,16 +20,18 @@ export const fetchGetPosts = async ({
   isSort,
   itemsPerPage,
   cursor,
+  isKeyword
 }: {
   isSort: 'mostRecent' | 'mostCommented' | 'mostLiked';
   itemsPerPage: number;
   cursor: number;
+  isKeyword:string
 }) => {
   try {
     const requestUrl =
       cursor === 1
-        ? `/posts?limit=${itemsPerPage}&orderBy=${isSort}`
-        : `/posts?limit=${itemsPerPage}&orderBy=${isSort}&cursor=${cursor}`;
+        ? `/posts?limit=${itemsPerPage}&orderBy=${isSort}&keyword=${isKeyword}`
+        : `/posts?limit=${itemsPerPage}&orderBy=${isSort}&cursor=${cursor}&keyword=${isKeyword}`;
 
     const response = await instance.get(requestUrl);
 

--- a/src/lib/fetch/post.ts
+++ b/src/lib/fetch/post.ts
@@ -16,14 +16,31 @@ export const fetchPostPosts = async () => {
 };
 
 // 게시글 목록 조회
-export const fetchGetPosts = async () => {
+export const fetchGetPosts = async ({
+  isSort,
+  itemsPerPage,
+  cursor,
+}: {
+  isSort: 'mostRecent' | 'mostCommented' | 'mostLiked';
+  itemsPerPage: number;
+  cursor: number;
+}) => {
   try {
-    const response = await instance.get('/posts');
+    const requestUrl =
+      cursor === 1
+        ? `/posts?limit=${itemsPerPage}&orderBy=${isSort}`
+        : `/posts?limit=${itemsPerPage}&orderBy=${isSort}&cursor=${cursor}`;
+
+    const response = await instance.get(requestUrl);
+
     if (!response.data) {
       throw new Error('게시물 데이터 불러오기 실패');
     }
-    const result = response.data;
-    return result;
+
+    return {
+      result: response.data.data,
+      nextPage: response.data.nextCursor,
+    };
   } catch (error) {
     console.error('게시물 데이터 불러오는 중 에러 발생:', error);
     throw error;


### PR DESCRIPTION
## 🔗 관련 이슈
- Close #85 #86 #87 

## 📌 PR 내용 요약
- 알바토크 리스트의 API를 연동하면서 데이터 출력, 무한스크롤 모두 구현 완료 했습니다. 기존에 만들어 놓은 무한스크롤 로직을 사용했기 때문에 추가된 커스텀 훅은 없습니다.

## ✨ 작업 내용
- API 연동 (+ 검색 및 정렬 기능)
- 데이터 출력
- 무한스크롤

## 🔍 테스트 방법 (선택)
![화면 기록 2025-05-30 오후 3 51 52](https://github.com/user-attachments/assets/20465f30-a569-4887-a378-91882f9cad93)

## ⚠️ 참고 및 공유 사항
- 기존에 만들어놓은 로직을 모두 가져와 사용하다보니 작업량을 배분하지 못하고 한꺼번에 작업하게 됐습니다. 양해 부탁드립니다🥹
