### PR TITLE
feat: 알바토크 생성 및 수정 API 연동

### DIFF
--- a/src/app/albatalk/[id]/components/KebabDropdown.tsx
+++ b/src/app/albatalk/[id]/components/KebabDropdown.tsx
@@ -6,6 +6,7 @@ import {
 } from '../styles';
 import { useClickOutside } from '@/hooks/common/useClickOutside';
 import { KebabDropdownProps } from '../types';
+import { useRouter } from 'next/navigation';
 
 export default function KebabDropdown({
   $deletePost,
@@ -17,6 +18,7 @@ export default function KebabDropdown({
   setSubMessage,
   setModalType,
 }: KebabDropdownProps) {
+  const router = useRouter();
   const { outRef, dropdown, setDropdown } = useClickOutside();
 
   const handleDeleteOpenModal = () => {
@@ -42,7 +44,12 @@ export default function KebabDropdown({
         onClick={() => setDropdown((prev) => !prev)}
       />
       <PostDropdownContainer $active={dropdown}>
-        <PostDropwonButton type='button'>수정하기</PostDropwonButton>
+        <PostDropwonButton
+          type='button'
+          onClick={() => router.push(`/albatalk/${postId}/edit`)}
+        >
+          수정하기
+        </PostDropwonButton>
         <PostDropwonButton type='button' onClick={handleDeleteOpenModal}>
           삭제하기
         </PostDropwonButton>

--- a/src/app/albatalk/[id]/edit/components/FormContainer.tsx
+++ b/src/app/albatalk/[id]/edit/components/FormContainer.tsx
@@ -1,14 +1,29 @@
+import { AlbatalkInput } from '@/schemas/albatalkSchema';
 import React from 'react';
+import { UseFormReturn } from 'react-hook-form';
 
 export default function FormContainer({
+  form,
+  isPending,
+  onSubmit,
   children,
 }: {
+  form: UseFormReturn<AlbatalkInput>;
+  isPending: boolean;
+  onSubmit: (formData: AlbatalkInput) => void;
   children: React.ReactNode;
 }) {
+  const { handleSubmit } = form;
+
   return (
     <div className='max-xs:pb-[calc(137px+theme(spacing.safe-bottom))]'>
-      <form>
-        <fieldset>{children}</fieldset>
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <fieldset
+          disabled={isPending}
+          className={`${isPending ? 'pointer-events-none' : ''}`}
+        >
+          {children}
+        </fieldset>
       </form>
     </div>
   );

--- a/src/app/albatalk/[id]/edit/components/FormContainer.tsx
+++ b/src/app/albatalk/[id]/edit/components/FormContainer.tsx
@@ -7,7 +7,9 @@ export default function FormContainer({
 }) {
   return (
     <div className='max-xs:pb-[calc(137px+theme(spacing.safe-bottom))]'>
-      <form>{children}</form>
+      <form>
+        <fieldset>{children}</fieldset>
+      </form>
     </div>
   );
 }

--- a/src/app/albatalk/[id]/edit/components/HeadContainer.tsx
+++ b/src/app/albatalk/[id]/edit/components/HeadContainer.tsx
@@ -1,7 +1,12 @@
 import { useRouter } from 'next/navigation';
+import { FormLogisProps } from '../../../types';
 
-export default function HeadContainer() {
+export default function HeadContainer(props: FormLogisProps) {
   const router = useRouter();
+
+  const { form, isModified, isPending } = props;
+  const { formState } = form;
+  const { isValid } = formState;
 
   return (
     <div className='flex items-center justify-between mt-[40px] pb-[35px] border-b border-solid border-line-100 max-md:pb-[18px] max-xs:pb-[16px]'>
@@ -16,8 +21,11 @@ export default function HeadContainer() {
         >
           취소
         </button>
-        <button className='w-[180px] h-[58px] bg-orange-400 text-white text-center font-medium rounded-[8px] max-xs:w-full max-md:w-[108px] max-md:h-[46px] max-xs:h-[58px]'>
-          수정하기
+        <button
+          className='w-[180px] h-[58px] bg-orange-400 text-white text-center font-medium rounded-[8px] max-xs:w-full max-md:w-[108px] max-md:h-[46px] max-xs:h-[58px] disabled:bg-gray-400 disabled:cursor-not-allowed'
+          disabled={!isValid || isPending || !isModified}
+        >
+          등록하기
         </button>
       </div>
     </div>

--- a/src/app/albatalk/[id]/edit/components/PostFormInputs.tsx
+++ b/src/app/albatalk/[id]/edit/components/PostFormInputs.tsx
@@ -1,6 +1,19 @@
+import useChangeProfilePreview from '@/hooks/common/useChangeProfilePreview';
 import Image from 'next/image';
+import { FormLogisProps } from '../../../types';
 
-export default function PostFormInputs() {
+export default function PostFormInputs(props: FormLogisProps) {
+  const { form, postByIdData, setSelectedImageFile } = props;
+
+  const { register, formState, setValue, trigger } = form;
+  const { errors } = formState;
+
+  const { title, content, imageUrl: currentImageUrl } = postByIdData ?? {};
+
+  const { isPreview, setIsPreview, handleImgChange } = useChangeProfilePreview(
+    currentImageUrl || '',
+  );
+
   return (
     <>
       <div className='mt-[70px] mb-[40px] max-md:mt-[32px]'>
@@ -12,12 +25,17 @@ export default function PostFormInputs() {
           <span className='text-orange-400 relative top-[1px] ml-[3px]'>*</span>
         </label>
         <input
+          {...register('title')}
           id='title'
           type='text'
+          defaultValue={title}
           placeholder='제목을 입력해주세요'
           maxLength={100}
           className='w-full bg-background-200 rounded-[8px] p-[14px]'
         />
+        {errors.title && (
+          <p className='text-left mt-[10px] text-red'>{errors.title.message}</p>
+        )}
       </div>
       <div className='mb-[40px]'>
         <label
@@ -29,26 +47,70 @@ export default function PostFormInputs() {
         </label>
         <textarea
           id='description'
+          {...register('description')}
+          defaultValue={content}
           placeholder='내용을 입력해주세요'
           className='w-full h-[240px] bg-background-200 rounded-[8px] p-[14px] max-md:h-[200px] max-xs:h-[180px]'
         />
+        {errors.description && (
+          <p className='text-left mt-[5px] text-red'>
+            {errors.description.message}
+          </p>
+        )}
       </div>
       <div>
         <p className='text-black300 font-medium mb-[15px]'>이미지</p>
-        <label
-          htmlFor='file-upload'
-          className='block w-[240px] h-[240px] rounded-[8px] bg-background-200 max-md:w-[160px] max-md:h-[160px] text-center place-content-center cursor-pointer'
-        >
-          <Image
-            src='/images/iconUpload.svg'
-            alt='Upload'
-            width={36}
-            height={36}
-            className='justify-self-center'
-          />
-          <p className='font-light text-gray-500'>이미지 넣기</p>
-        </label>
-        <input id='file-upload' type='file' className='hidden' />
+        {isPreview ? (
+          <div className='relative w-fit'>
+            <div className='relative w-[240px] h-[240px] rounded-[8px] max-md:w-[160px] max-md:h-[160px] border border-solid border-line-200 overflow-hidden'>
+              <Image src={isPreview} alt='썸네일' fill />
+            </div>
+            <Image
+              src='/images/closePreview.svg'
+              alt='X'
+              width={24}
+              height={24}
+              className='absolute z-[100] top-[-5px] right-[-5px] cursor-pointer'
+              onClick={() => {
+                setIsPreview('');
+                setSelectedImageFile?.(null);
+                setValue('imageUrl', '', {
+                  shouldDirty: true,
+                });
+                trigger('imageUrl');
+              }}
+            />
+          </div>
+        ) : (
+          <label
+            htmlFor='file-upload'
+            className='block w-[240px] h-[240px] rounded-[8px] bg-background-200 max-md:w-[160px] max-md:h-[160px] text-center place-content-center cursor-pointer'
+          >
+            <Image
+              src='/images/iconUpload.svg'
+              alt='Upload'
+              width={36}
+              height={36}
+              className='justify-self-center'
+            />
+            <p className='font-light text-gray-500'>이미지 넣기</p>
+          </label>
+        )}
+        <input
+          id='file-upload'
+          type='file'
+          accept='image/png, image/jpg'
+          className='hidden'
+          onChange={(e) => {
+            const file = e.target.files?.[0];
+            handleImgChange(e);
+            setSelectedImageFile?.(file!);
+            setValue('imageUrl', file ? file.name : '', {
+              shouldDirty: true,
+            });
+            trigger('imageUrl');
+          }}
+        />
       </div>
     </>
   );

--- a/src/app/albatalk/[id]/edit/hooks/useEditForm.ts
+++ b/src/app/albatalk/[id]/edit/hooks/useEditForm.ts
@@ -1,0 +1,89 @@
+import { useEditPosts } from '@/hooks/mutation/useEditPosts';
+import { usePostPosts } from '@/hooks/mutation/usePostPosts';
+import { useUploadImage } from '@/hooks/mutation/useUploadImage';
+import { useGetPostsById } from '@/hooks/query/useGetPostsById';
+import { AlbatalkInput, editAlbatalkSchema } from '@/schemas/albatalkSchema';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useQueryClient } from '@tanstack/react-query';
+import { useParams, useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+
+export const useEditForm = () => {
+  const router = useRouter();
+  const params = useParams();
+  const postId = Number(params.id);
+
+  const queryClient = useQueryClient();
+
+  const [selectedImageFile, setSelectedImageFile] = useState<File | null>(null);
+
+  const { data: postByIdData } = useGetPostsById(postId);
+  const { mutateAsync: uploadImage, isPending: isUploadingImage } =
+    useUploadImage();
+  const { mutate: patchEditPosts, isPending: isUploadingPost } = useEditPosts();
+
+  const form = useForm<AlbatalkInput>({
+    resolver: zodResolver(editAlbatalkSchema),
+    mode: 'onChange',
+    defaultValues: {
+      title: postByIdData?.title,
+      description: postByIdData?.content,
+      imageUrl: postByIdData?.imageUrl,
+    },
+  });
+
+  const { watch, setValue } = form;
+  const watched = watch();
+
+  useEffect(() => {
+    if (postByIdData) {
+      setValue('title', postByIdData.title || '');
+      setValue('description', postByIdData.content || '');
+      setValue('imageUrl', postByIdData.imageUrl || '');
+    }
+  }, [postByIdData, setValue]);
+
+  const isModified =
+    watched.title !== postByIdData?.title ||
+    watched.description !== postByIdData?.content ||
+    watched.imageUrl !== postByIdData?.imageUrl;
+
+  const isPending = isUploadingImage || isUploadingPost;
+
+  const onSubmit = async (formData: AlbatalkInput) => {
+    let imageUrl;
+    if (selectedImageFile) {
+      imageUrl = await uploadImage(selectedImageFile);
+    }
+
+    const payload = {
+      ...formData,
+      imageUrl,
+    };
+
+    const refetchPosts = async () => {
+      queryClient.invalidateQueries({ queryKey: ['posts'], exact: false });
+    };
+
+    patchEditPosts(
+      { postId, payload },
+      {
+        onSuccess: async () => {
+          await refetchPosts();
+          router.push(`/albatalk/${postId}`);
+        },
+      },
+    );
+  };
+
+  return {
+    postByIdData,
+    form,
+    onSubmit,
+    selectedImageFile,
+    setSelectedImageFile,
+    isModified,
+    isPending,
+  };
+};

--- a/src/app/albatalk/[id]/edit/hooks/useEditForm.ts
+++ b/src/app/albatalk/[id]/edit/hooks/useEditForm.ts
@@ -57,6 +57,8 @@ export const useEditForm = () => {
       imageUrl = await uploadImage(selectedImageFile);
     } else if (formData.imageUrl === '') {
       imageUrl = '';
+    } else {
+      imageUrl = postByIdData?.imageUrl || '';
     }
 
     const payload = {

--- a/src/app/albatalk/[id]/edit/hooks/useEditForm.ts
+++ b/src/app/albatalk/[id]/edit/hooks/useEditForm.ts
@@ -55,6 +55,8 @@ export const useEditForm = () => {
     let imageUrl;
     if (selectedImageFile) {
       imageUrl = await uploadImage(selectedImageFile);
+    } else if (formData.imageUrl === '') {
+      imageUrl = '';
     }
 
     const payload = {

--- a/src/app/albatalk/[id]/edit/hooks/useEditForm.ts
+++ b/src/app/albatalk/[id]/edit/hooks/useEditForm.ts
@@ -1,10 +1,9 @@
 import { useEditPosts } from '@/hooks/mutation/useEditPosts';
-import { usePostPosts } from '@/hooks/mutation/usePostPosts';
 import { useUploadImage } from '@/hooks/mutation/useUploadImage';
 import { useGetPostsById } from '@/hooks/query/useGetPostsById';
 import { AlbatalkInput, editAlbatalkSchema } from '@/schemas/albatalkSchema';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useQueryClient } from '@tanstack/react-query';
+import { useIsFetching, useQueryClient } from '@tanstack/react-query';
 import { useParams, useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
@@ -49,7 +48,8 @@ export const useEditForm = () => {
     watched.description !== postByIdData?.content ||
     watched.imageUrl !== postByIdData?.imageUrl;
 
-  const isPending = isUploadingImage || isUploadingPost;
+  const isFetching = useIsFetching({ queryKey: ['post', postId] });
+  const isPending = isUploadingImage || isUploadingPost || !!isFetching;
 
   const onSubmit = async (formData: AlbatalkInput) => {
     let imageUrl;
@@ -63,7 +63,11 @@ export const useEditForm = () => {
     };
 
     const refetchPosts = async () => {
-      queryClient.invalidateQueries({ queryKey: ['posts'], exact: false });
+      await queryClient.invalidateQueries({
+        queryKey: ['posts'],
+        exact: false,
+      });
+      await queryClient.invalidateQueries({ queryKey: ['post', postId] });
     };
 
     patchEditPosts(

--- a/src/app/albatalk/[id]/edit/page.tsx
+++ b/src/app/albatalk/[id]/edit/page.tsx
@@ -3,15 +3,29 @@ import { ResponsiveStyle } from '@/styles/responsiveStyle';
 import HeadContainer from './components/HeadContainer';
 import FormContainer from './components/FormContainer';
 import PostFormInputs from './components/PostFormInputs';
+import { useEditForm } from './hooks/useEditForm';
+import Image from 'next/image';
 
-export default function EditAlbatalk() {
+export default function NewAlbatalk() {
+  const formLogic =  useEditForm();
+
   return (
     <>
       <ResponsiveStyle>
-        <FormContainer>
-          <HeadContainer />
-          <PostFormInputs />
+        <FormContainer {...formLogic}>
+          <HeadContainer {...formLogic} />
+          <PostFormInputs {...formLogic} />
         </FormContainer>
+        {formLogic.isPending && (
+          <div className='absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2'>
+            <Image
+              src='/images/loader.gif'
+              alt='Loading...'
+              width={80}
+              height={80}
+            />
+          </div>
+        )}
       </ResponsiveStyle>
     </>
   );

--- a/src/app/albatalk/components/FloatingButton.tsx
+++ b/src/app/albatalk/components/FloatingButton.tsx
@@ -1,8 +1,14 @@
 import Image from 'next/image';
+import { useRouter } from 'next/navigation';
 
 export default function FloatingButton() {
+  const router = useRouter();
+
   return (
-    <div className='fixed rounded-[50%] bg-primary-orange300 w-[64px] h-[64px] content-center justify-items-center bottom-[calc(100px+theme(spacing.safe-bottom))] right-[120px] min-xlg:right-[calc((100vw-1480px)/2)] max-md:right-[24px] cursor-pointer'>
+    <div
+      className='fixed rounded-[50%] bg-primary-orange300 w-[64px] h-[64px] content-center justify-items-center bottom-[calc(100px+theme(spacing.safe-bottom))] right-[120px] min-xlg:right-[calc((100vw-1480px)/2)] max-md:right-[24px] cursor-pointer'
+      onClick={() => router.push('albatalk/new')}
+    >
       <Image
         src='/images/albatalk/iconWrite.svg'
         alt='작성하기'

--- a/src/app/albatalk/new/components/FormContainer.tsx
+++ b/src/app/albatalk/new/components/FormContainer.tsx
@@ -1,13 +1,30 @@
+import { AlbatalkInput } from '@/schemas/albatalkSchema';
 import React from 'react';
+import { UseFormReturn } from 'react-hook-form';
 
 export default function FormContainer({
+  form,
+  isPending,
+  onSubmit,
   children,
 }: {
+  form: UseFormReturn<AlbatalkInput>;
+  isPending: boolean;
+  onSubmit: (formData: AlbatalkInput) => void;
   children: React.ReactNode;
 }) {
+  const { handleSubmit } = form;
+
   return (
     <div className='max-xs:pb-[calc(137px+theme(spacing.safe-bottom))]'>
-      <form>{children}</form>
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <fieldset
+          disabled={isPending}
+          className={`${isPending ? 'pointer-events-none' : ''}`}
+        >
+          {children}
+        </fieldset>
+      </form>
     </div>
   );
 }

--- a/src/app/albatalk/new/components/HeadContainer.tsx
+++ b/src/app/albatalk/new/components/HeadContainer.tsx
@@ -1,7 +1,12 @@
 import { useRouter } from 'next/navigation';
+import { FormLogisProps } from '../../types';
 
-export default function HeadContainer() {
+export default function HeadContainer(props: FormLogisProps) {
   const router = useRouter();
+
+  const { form, isPending } = props;
+  const { formState } = form;
+  const { isValid } = formState;
 
   return (
     <div className='flex items-center justify-between mt-[40px] pb-[35px] border-b border-solid border-line-100 max-md:pb-[18px] max-xs:pb-[16px]'>
@@ -16,7 +21,10 @@ export default function HeadContainer() {
         >
           취소
         </button>
-        <button className='w-[180px] h-[58px] bg-orange-400 text-white text-center font-medium rounded-[8px] max-xs:w-full max-md:w-[108px] max-md:h-[46px] max-xs:h-[58px]'>
+        <button
+          className='w-[180px] h-[58px] bg-orange-400 text-white text-center font-medium rounded-[8px] max-xs:w-full max-md:w-[108px] max-md:h-[46px] max-xs:h-[58px] disabled:bg-gray-400 disabled:cursor-not-allowed'
+          disabled={!isValid || isPending}
+        >
           등록하기
         </button>
       </div>

--- a/src/app/albatalk/new/components/PostFormInputs.tsx
+++ b/src/app/albatalk/new/components/PostFormInputs.tsx
@@ -1,6 +1,16 @@
+import useChangeProfilePreview from '@/hooks/common/useChangeProfilePreview';
 import Image from 'next/image';
+import { FormLogisProps } from '../../types';
 
-export default function PostFormInputs() {
+export default function PostFormInputs(props: FormLogisProps) {
+  const { form, setSelectedImageFile } = props;
+
+  const { register, formState, setValue, trigger } = form;
+  const { errors } = formState;
+
+  const { isPreview, setIsPreview, handleImgChange } =
+    useChangeProfilePreview('');
+
   return (
     <>
       <div className='mt-[70px] mb-[40px] max-md:mt-[32px]'>
@@ -12,12 +22,16 @@ export default function PostFormInputs() {
           <span className='text-orange-400 relative top-[1px] ml-[3px]'>*</span>
         </label>
         <input
+          {...register('title')}
           id='title'
           type='text'
           placeholder='제목을 입력해주세요'
           maxLength={100}
           className='w-full bg-background-200 rounded-[8px] p-[14px]'
         />
+        {errors.title && (
+          <p className='text-left mt-[10px] text-red'>{errors.title.message}</p>
+        )}
       </div>
       <div className='mb-[40px]'>
         <label
@@ -29,26 +43,69 @@ export default function PostFormInputs() {
         </label>
         <textarea
           id='description'
+          {...register('description')}
           placeholder='내용을 입력해주세요'
           className='w-full h-[240px] bg-background-200 rounded-[8px] p-[14px] max-md:h-[200px] max-xs:h-[180px]'
         />
+        {errors.description && (
+          <p className='text-left mt-[5px] text-red'>
+            {errors.description.message}
+          </p>
+        )}
       </div>
       <div>
         <p className='text-black300 font-medium mb-[15px]'>이미지</p>
-        <label
-          htmlFor='file-upload'
-          className='block w-[240px] h-[240px] rounded-[8px] bg-background-200 max-md:w-[160px] max-md:h-[160px] text-center place-content-center cursor-pointer'
-        >
-          <Image
-            src='/images/iconUpload.svg'
-            alt='Upload'
-            width={36}
-            height={36}
-            className='justify-self-center'
-          />
-          <p className='font-light text-gray-500'>이미지 넣기</p>
-        </label>
-        <input id='file-upload' type='file' className='hidden' />
+        {isPreview ? (
+          <div className='relative w-fit'>
+            <div className='relative w-[240px] h-[240px] rounded-[8px] max-md:w-[160px] max-md:h-[160px] border border-solid border-line-200 overflow-hidden'>
+              <Image src={isPreview} alt='썸네일' fill />
+            </div>
+            <Image
+              src='/images/closePreview.svg'
+              alt='X'
+              width={24}
+              height={24}
+              className='absolute z-[100] top-[-5px] right-[-5px] cursor-pointer'
+              onClick={() => {
+                setIsPreview('');
+                setSelectedImageFile?.(null);
+                setValue('imageUrl', '', {
+                  shouldDirty: true,
+                });
+                trigger('imageUrl');
+              }}
+            />
+          </div>
+        ) : (
+          <label
+            htmlFor='file-upload'
+            className='block w-[240px] h-[240px] rounded-[8px] bg-background-200 max-md:w-[160px] max-md:h-[160px] text-center place-content-center cursor-pointer'
+          >
+            <Image
+              src='/images/iconUpload.svg'
+              alt='Upload'
+              width={36}
+              height={36}
+              className='justify-self-center'
+            />
+            <p className='font-light text-gray-500'>이미지 넣기</p>
+          </label>
+        )}
+        <input
+          id='file-upload'
+          type='file'
+          accept='image/png, image/jpg'
+          className='hidden'
+          onChange={(e) => {
+            const file = e.target.files?.[0];
+            handleImgChange(e);
+            setSelectedImageFile?.(file!);
+            setValue('imageUrl', file ? file.name : '', {
+              shouldDirty: true,
+            });
+            trigger('imageUrl');
+          }}
+        />
       </div>
     </>
   );

--- a/src/app/albatalk/new/hooks/useCreateForm.ts
+++ b/src/app/albatalk/new/hooks/useCreateForm.ts
@@ -1,0 +1,60 @@
+import { usePostPosts } from '@/hooks/mutation/usePostPosts';
+import { useUploadImage } from '@/hooks/mutation/useUploadImage';
+import { AlbatalkInput, newAlbatalkSchema } from '@/schemas/albatalkSchema';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useQueryClient } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+
+export const useCreateForm = () => {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+
+  const [selectedImageFile, setSelectedImageFile] = useState<File | null>(null);
+
+  const { mutateAsync: uploadImage, isPending: isUploadingImage } =
+    useUploadImage();
+  const { mutate: patchPostPosts, isPending: isUploadingPost } = usePostPosts();
+
+  const isPending = isUploadingImage || isUploadingPost;
+
+  const form = useForm<AlbatalkInput>({
+    resolver: zodResolver(newAlbatalkSchema),
+    mode: 'onChange',
+    defaultValues: {
+      imageUrl: '',
+    },
+  });
+
+  const onSubmit = async (formData: AlbatalkInput) => {
+    let imageUrl;
+    if (selectedImageFile) {
+      imageUrl = await uploadImage(selectedImageFile);
+    }
+
+    const payload = {
+      ...formData,
+      imageUrl,
+    };
+
+    const refetchPosts = async () => {
+      queryClient.invalidateQueries({ queryKey: ['posts'], exact: false });
+    };
+
+    patchPostPosts(payload, {
+      onSuccess: async () => {
+        await refetchPosts();
+        router.push('/albatalk');
+      },
+    });
+  };
+
+  return {
+    form,
+    onSubmit,
+    selectedImageFile,
+    setSelectedImageFile,
+    isPending,
+  };
+};

--- a/src/app/albatalk/new/hooks/useCreateForm.ts
+++ b/src/app/albatalk/new/hooks/useCreateForm.ts
@@ -15,7 +15,9 @@ export const useCreateForm = () => {
 
   const { mutateAsync: uploadImage, isPending: isUploadingImage } =
     useUploadImage();
-  const { mutate: patchPostPosts, isPending: isUploadingPost } = usePostPosts();
+
+  const { mutateAsync: patchPostPosts, isPending: isUploadingPost } =
+    usePostPosts();
 
   const isFetching = useIsFetching({ queryKey: ['posts'] }) > 0;
   const isPending = isUploadingImage || isUploadingPost || isFetching;
@@ -39,19 +41,16 @@ export const useCreateForm = () => {
       imageUrl,
     };
 
-    const refetchPosts = async () => {
-      await queryClient.invalidateQueries({
-        queryKey: ['posts'],
-        exact: false,
-      });
-    };
+    // const refetchPosts = async () => {
+    //   await queryClient.invalidateQueries({
+    //     queryKey: ['posts'],
+    //     exact: false,
+    //   });
+    // };
 
-    patchPostPosts(payload, {
-      onSuccess: async () => {
-        await refetchPosts();
-        router.push('/albatalk');
-      },
-    });
+    const data = await patchPostPosts(payload);
+    await queryClient.invalidateQueries({ queryKey: ['posts'], exact: false });
+    router.push(`/albatalk/${data.id}`);
   };
 
   return {

--- a/src/app/albatalk/new/hooks/useCreateForm.ts
+++ b/src/app/albatalk/new/hooks/useCreateForm.ts
@@ -41,13 +41,6 @@ export const useCreateForm = () => {
       imageUrl,
     };
 
-    // const refetchPosts = async () => {
-    //   await queryClient.invalidateQueries({
-    //     queryKey: ['posts'],
-    //     exact: false,
-    //   });
-    // };
-
     const data = await patchPostPosts(payload);
     await queryClient.invalidateQueries({ queryKey: ['posts'], exact: false });
     router.push(`/albatalk/${data.id}`);

--- a/src/app/albatalk/new/hooks/useCreateForm.ts
+++ b/src/app/albatalk/new/hooks/useCreateForm.ts
@@ -2,7 +2,7 @@ import { usePostPosts } from '@/hooks/mutation/usePostPosts';
 import { useUploadImage } from '@/hooks/mutation/useUploadImage';
 import { AlbatalkInput, newAlbatalkSchema } from '@/schemas/albatalkSchema';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useQueryClient } from '@tanstack/react-query';
+import { useIsFetching, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
@@ -17,7 +17,8 @@ export const useCreateForm = () => {
     useUploadImage();
   const { mutate: patchPostPosts, isPending: isUploadingPost } = usePostPosts();
 
-  const isPending = isUploadingImage || isUploadingPost;
+  const isFetching = useIsFetching({ queryKey: ['posts'] }) > 0;
+  const isPending = isUploadingImage || isUploadingPost || isFetching;
 
   const form = useForm<AlbatalkInput>({
     resolver: zodResolver(newAlbatalkSchema),
@@ -39,7 +40,10 @@ export const useCreateForm = () => {
     };
 
     const refetchPosts = async () => {
-      queryClient.invalidateQueries({ queryKey: ['posts'], exact: false });
+      await queryClient.invalidateQueries({
+        queryKey: ['posts'],
+        exact: false,
+      });
     };
 
     patchPostPosts(payload, {

--- a/src/app/albatalk/new/page.tsx
+++ b/src/app/albatalk/new/page.tsx
@@ -3,15 +3,29 @@ import { ResponsiveStyle } from '@/styles/responsiveStyle';
 import HeadContainer from './components/HeadContainer';
 import FormContainer from './components/FormContainer';
 import PostFormInputs from './components/PostFormInputs';
+import { useCreateForm } from './hooks/useCreateForm';
+import Image from 'next/image';
 
 export default function NewAlbatalk() {
+  const formLogic = useCreateForm();
+
   return (
     <>
       <ResponsiveStyle>
-        <FormContainer>
-          <HeadContainer />
-          <PostFormInputs />
+        <FormContainer {...formLogic}>
+          <HeadContainer {...formLogic} />
+          <PostFormInputs {...formLogic} />
         </FormContainer>
+        {formLogic.isPending && (
+          <div className='absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2'>
+            <Image
+              src='/images/loader.gif'
+              alt='Loading...'
+              width={80}
+              height={80}
+            />
+          </div>
+        )}
       </ResponsiveStyle>
     </>
   );

--- a/src/app/albatalk/types.ts
+++ b/src/app/albatalk/types.ts
@@ -1,4 +1,6 @@
+import { AlbatalkInput } from '@/schemas/albatalkSchema';
 import { Dispatch, SetStateAction } from 'react';
+import { FieldValues } from 'react-hook-form';
 
 export interface FilterContainerProps {
   isSort: 'mostRecent' | 'mostCommented' | 'mostLiked';
@@ -36,4 +38,10 @@ export interface ListContainerProps {
   listData: ListData[];
   isLoading: boolean;
   isFetchingNextPage: boolean;
+}
+
+export interface FormLogisProps {
+  form: FieldValues;
+  isPending?: boolean;
+  setSelectedImageFile?: Dispatch<SetStateAction<File | null>>;
 }

--- a/src/app/albatalk/types.ts
+++ b/src/app/albatalk/types.ts
@@ -42,6 +42,8 @@ export interface ListContainerProps {
 
 export interface FormLogisProps {
   form: FieldValues;
+  postByIdData?: ListData;
+  isModified?: boolean;
   isPending?: boolean;
   setSelectedImageFile?: Dispatch<SetStateAction<File | null>>;
 }

--- a/src/app/mypage/components/KebabDropdown.tsx
+++ b/src/app/mypage/components/KebabDropdown.tsx
@@ -6,6 +6,7 @@ import {
 } from '../styles';
 import { useClickOutside } from '@/hooks/common/useClickOutside';
 import { KebabDropdownProps } from '../types';
+import { useRouter } from 'next/navigation';
 
 export default function KebabDropdown({
   postId,
@@ -15,6 +16,7 @@ export default function KebabDropdown({
   setSubMessage,
   setModalType,
 }: KebabDropdownProps) {
+  const router = useRouter();
   const { outRef, dropdown, setDropdown } = useClickOutside();
 
   const handleDeleteOpenModal = () => {
@@ -33,11 +35,28 @@ export default function KebabDropdown({
         width={36}
         height={36}
         className='cursor-pointer'
-        onClick={() => setDropdown((prev) => !prev)}
+        onClick={(e) => {
+          e.stopPropagation();
+          setDropdown((prev) => !prev);
+        }}
       />
       <PostDropdownContainer $active={dropdown}>
-        <PostDropwonButton type='button'>수정하기</PostDropwonButton>
-        <PostDropwonButton type='button' onClick={handleDeleteOpenModal}>
+        <PostDropwonButton
+          type='button'
+          onClick={(e) => {
+            e.stopPropagation();
+            router.push(`/albatalk/${postId}/edit`);
+          }}
+        >
+          수정하기
+        </PostDropwonButton>
+        <PostDropwonButton
+          type='button'
+          onClick={(e) => {
+            e.stopPropagation();
+            handleDeleteOpenModal();
+          }}
+        >
           삭제하기
         </PostDropwonButton>
       </PostDropdownContainer>

--- a/src/app/mypage/components/modal/EditProfile/EditProfileForm.tsx
+++ b/src/app/mypage/components/modal/EditProfile/EditProfileForm.tsx
@@ -54,7 +54,7 @@ export default function EditProfileForm(props: EditProfileFormProps) {
               alt='기본 이미지'
               width={80}
               height={80}
-              className='rounded-[50%] overflow-hidden object-cover min-h-[80px]'
+              className='rounded-[50%] overflow-hidden object-cover max-h-[80px] min-h-[80px]'
             />
             <Image
               src='/images/mypage/iconEditImg.svg'

--- a/src/hooks/mutation/useEditPosts.ts
+++ b/src/hooks/mutation/useEditPosts.ts
@@ -1,2 +1,11 @@
 // 게시글 수정하기
+
+import { fetchEditPosts } from "@/lib/fetch/post";
+import { useMutation } from "@tanstack/react-query";
+
 // PATCH '/posts/:postId'
+export const useEditPosts = () => {
+  return useMutation({
+    mutationFn: fetchEditPosts,
+  });
+};

--- a/src/hooks/mutation/usePostPosts.ts
+++ b/src/hooks/mutation/usePostPosts.ts
@@ -1,2 +1,11 @@
 // 게시글 등록하기
+
+import { fetchPostPosts } from '@/lib/fetch/post';
+import { useMutation } from '@tanstack/react-query';
+
 // POST '/posts'
+export const usePostPosts = () => {
+  return useMutation({
+    mutationFn: fetchPostPosts,
+  });
+};

--- a/src/lib/fetch/post.ts
+++ b/src/lib/fetch/post.ts
@@ -13,6 +13,9 @@ export const fetchPostPosts = async (payload: AlbatalkInput) => {
     if (!response.data) {
       throw new Error('게시물 데이터 불러오기 실패');
     }
+
+    const result = response.data;
+    return result;
   } catch (error) {
     console.error('게시물 데이터 불러오는 중 에러 발생:', error);
     throw error;

--- a/src/lib/fetch/post.ts
+++ b/src/lib/fetch/post.ts
@@ -69,14 +69,24 @@ export const fetchGetPostsById = async (postId: number) => {
 };
 
 // 게시글 수정
-export const fetchEditPosts = async (postId: number) => {
+export const fetchEditPosts = async ({
+  postId,
+  payload,
+}: {
+  postId: number;
+  payload: AlbatalkInput;
+}) => {
+  const { title, description: content, imageUrl } = payload;
+
   try {
-    const response = await instance.patch(`/posts/${postId}`);
+    const response = await instance.patch(`/posts/${postId}`, {
+      title,
+      content,
+      imageUrl,
+    });
     if (!response.data) {
       throw new Error('게시물 데이터 수정 실패');
     }
-    const result = response.data;
-    return result;
   } catch (error) {
     console.error('게시물 데이터 수정 중 에러 발생:', error);
     throw error;

--- a/src/lib/fetch/post.ts
+++ b/src/lib/fetch/post.ts
@@ -1,14 +1,18 @@
+import { AlbatalkInput } from '@/schemas/albatalkSchema';
 import instance from '../api/api';
 
 // 게시글 등록
-export const fetchPostPosts = async () => {
+export const fetchPostPosts = async (payload: AlbatalkInput) => {
+  const { title, description: content, imageUrl } = payload;
   try {
-    const response = await instance.post('/posts');
+    const response = await instance.post('/posts', {
+      title,
+      content,
+      imageUrl,
+    });
     if (!response.data) {
       throw new Error('게시물 데이터 불러오기 실패');
     }
-    const result = response.data;
-    return result;
   } catch (error) {
     console.error('게시물 데이터 불러오는 중 에러 발생:', error);
     throw error;
@@ -20,12 +24,12 @@ export const fetchGetPosts = async ({
   isSort,
   itemsPerPage,
   cursor,
-  isKeyword
+  isKeyword,
 }: {
   isSort: 'mostRecent' | 'mostCommented' | 'mostLiked';
   itemsPerPage: number;
   cursor: number;
-  isKeyword:string
+  isKeyword: string;
 }) => {
   try {
     const requestUrl =

--- a/src/schemas/albatalkSchema.ts
+++ b/src/schemas/albatalkSchema.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+export const baseAlbatalkSchema = z.object({
+  title: z.string().min(1, '제목은 필수입니다'),
+  description: z.string().min(1, '내용은 필수입니다'),
+  imageUrl: z.string(),
+});
+
+export const newAlbatalkSchema = baseAlbatalkSchema.extend({});
+export const editAlbatalkSchema = baseAlbatalkSchema.extend({});
+
+export type AlbatalkInput = z.infer<typeof baseAlbatalkSchema>;


### PR DESCRIPTION
## 🔗 관련 이슈
- Close #88 #105 #106 #111 #113 #114 

## 📌 PR 내용 요약
- 알바토크 게시글 생성 및 수정 관련 기능 모두 구현 완료 되었습니다.

## ✨ 작업 내용
- 게시글 생성 API 연동
- 게시글 수정 API 연동
- Loading 및 Fetching UI 추가
- 각 버튼 페이지 경로 연결

## 🔍 테스트 방법 (선택)
![화면 기록 2025-06-07 오후 6 20 23](https://github.com/user-attachments/assets/d1cfd688-1b9f-4d5e-a945-ff01c15198b1)

## ⚠️ 참고 및 공유 사항
- 프로젝트 스케줄 관계로 해당 PR에 작업분량이 많습니다.
