### PR TITLE
feat: 지원자 > 내 알바폼 UIUX 및 API 연동 / 무한스크롤 구현

### DIFF
--- a/src/app/myAlbaform/applicant/components/ContentsList.tsx
+++ b/src/app/myAlbaform/applicant/components/ContentsList.tsx
@@ -1,0 +1,92 @@
+import Loader from '@/components/loader/Loader';
+import { useImgError } from '@/hooks/common/useImgError';
+import { Description, PostWrapper, Title } from '../../styles';
+import Empty from '@/components/empty/Empty';
+import Image from 'next/image';
+import { formattedDate } from '@/utils/formattedDate';
+import { ListContainerProps } from '../../types';
+import { useRouter } from 'next/navigation';
+import getRecruitStatus from '@/utils/getRecruitStatus';
+
+export default function ContentsList({
+  listData,
+  isLoading,
+  isFetchingNextPage,
+}: ListContainerProps) {
+  const router = useRouter();
+
+  const { img, defaultImg, handleImgError } = useImgError(
+    '/images/defaultProfile.svg',
+  );
+  return (
+    <>
+      {!isLoading && listData?.length === 0 ? (
+        <Empty albatalk />
+      ) : (
+        <div className='min-lg:min-h-[500px]'>
+          <div className='flex flex-wrap gap-x-[2%] gap-y-[48px] max-lg:gap-y-[16px]'>
+            {(isLoading || isFetchingNextPage) && <Loader />}
+            {listData.map((item) => {
+              const { form } = item;
+              const { owner } = form;
+
+              return (
+                <PostWrapper key={item.id}>
+                  <div className='flex items-center justify-between mb-6'>
+                    <p className='text-gray400 font-light'>
+                      {formattedDate(item.createdAt)}
+                    </p>
+                    <button
+                      type='button'
+                      className='underline text-black200 font-light'
+                    >
+                      지원내역 보기
+                    </button>
+                  </div>
+                  <div className='flex items-center mb-4'>
+                    <Image
+                      src={
+                        img[String(owner.imageUrl)] ||
+                        owner.imageUrl ||
+                        defaultImg
+                      }
+                      alt='기본프로필'
+                      width={48}
+                      height={48}
+                      className='mr-[5px] rounded-[50%] object-cover border border-gray500 min-h-[26px]'
+                      onError={() => handleImgError(String(owner.imageUrl))}
+                    />
+                    <p className='ml-[10px] text-black300'>{owner.storeName}</p>
+                  </div>
+                  <div className='mb-6'>
+                    <Title>{form.title}</Title>
+                    <Description>{form.description}</Description>
+                  </div>
+                  <div className='flex items-center'>
+                    <div className='h-[38px] px-3 bg-orange-100 text-orange-400 border-orange100 border border-solid rounded leading-[38px] mr-[8px]'>
+                      {item.status === 'REJECTED'
+                        ? '거절'
+                        : item.status === 'INTERVIEW_PENDING'
+                        ? '면접 대기'
+                        : item.status === 'INTERVIEW_COMPLETED'
+                        ? '면접 완료'
+                        : item.status === 'HIRED'
+                        ? '채용 완료'
+                        : ''}
+                    </div>
+                    <div className='h-[38px] px-3 bg-orange-100 text-orange-400 border border-solid border-orange100 rounded leading-[38px]'>
+                      {getRecruitStatus(
+                        form.recruitmentStartDate,
+                        form.recruitmentEndDate,
+                      )}
+                    </div>
+                  </div>
+                </PostWrapper>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/app/myAlbaform/applicant/components/FilterContainer.tsx
+++ b/src/app/myAlbaform/applicant/components/FilterContainer.tsx
@@ -1,0 +1,35 @@
+import Image from 'next/image';
+import React from 'react';
+import { FilterContainerProps } from '../../types';
+
+export default function FilterContainer({ setKeyword }: FilterContainerProps) {
+  const handleEnterSearch = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    const formData = new FormData(e.currentTarget);
+    const keyword = formData.get('search') as string;
+
+    setKeyword(keyword);
+  };
+
+  return (
+    <div className='flex justify-between items-center max-xs:flex-col max-xs:items-stretch'>
+      <form onSubmit={handleEnterSearch} className='flex-[1]'>
+        <div className='flex bg-background-200 rounded-[24px] px-[24px] py-[14px] max-md:px-[14px] w-1/2 max-md:w-full'>
+          <Image
+            src='/images/iconSearch.svg'
+            alt='검색'
+            width={36}
+            height={36}
+          />
+          <input
+            name='search'
+            type='text'
+            placeholder='어떤 알바를 찾고 계세요?'
+            className='ml-[8px] bg-background-200 text-[20px] w-full max-md:text-[16px] max-md:ml-[2px]'
+          />
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/app/myAlbaform/applicant/components/statusSort/StatusSortButton.tsx
+++ b/src/app/myAlbaform/applicant/components/statusSort/StatusSortButton.tsx
@@ -1,0 +1,58 @@
+import Image from 'next/image';
+import { useClickOutside } from '@/hooks/common/useClickOutside';
+import { DropdownBox, DropdownContainer } from './styles';
+import { StatusDropdownProps } from './type';
+import StatusSortDropdown from './StatusSortDropdown';
+
+export default function StatusSortButton({
+  status,
+  setStatus,
+}: StatusDropdownProps) {
+  const { outRef, dropdown, setDropdown } = useClickOutside();
+  return (
+    <>
+      <div
+        className='w-[130px] px-4 py-2 rounded relative border border-solid font-light border-gray-200 text-black100 max-md:w-[100px] max-md:px-[10px] max-md:py-[6px]'
+        ref={outRef}
+      >
+        <button
+          className='flex w-full items-center justify-between'
+          onClick={() => setDropdown((prev) => !prev)}
+        >
+          <p className='pr-1 ml-[5px] min-w-[max-content] max-md:text-[12px]'>
+            {status === ''
+              ? '전체'
+              : status === 'REJECTED'
+              ? '거절'
+              : status === 'INTERVIEW_PENDING'
+              ? '면접 대기'
+              : status === 'INTERVIEW_COMPLETED'
+              ? '면접 완료'
+              : status === 'HIRED'
+              ? '채용 완료'
+              : ''}
+          </p>
+          <div className='relative w-6 h-6 max-md:w-4 max-md:h-4'>
+            <Image
+              src='/images/arrowDown.svg'
+              alt='arrow_down'
+              fill
+              className={
+                dropdown
+                  ? 'rotate-180 transition-transform duration-200'
+                  : 'transition-transform duration-200'
+              }
+            />
+          </div>
+        </button>
+        <DropdownContainer $active={dropdown}>
+          {dropdown && (
+            <DropdownBox>
+              <StatusSortDropdown status={status} setStatus={setStatus} />
+            </DropdownBox>
+          )}
+        </DropdownContainer>
+      </div>
+    </>
+  );
+}

--- a/src/app/myAlbaform/applicant/components/statusSort/StatusSortDropdown.tsx
+++ b/src/app/myAlbaform/applicant/components/statusSort/StatusSortDropdown.tsx
@@ -1,0 +1,57 @@
+import { DropdownButton } from './styles';
+import { StatusDropdownProps } from './type';
+
+export default function StatusSortDropdown({
+  status,
+  setStatus,
+}: StatusDropdownProps) {
+  return (
+    <>
+      <DropdownButton
+        type='button'
+        $active={status === ''}
+        onClick={() => {
+          setStatus('');
+        }}
+      >
+        전체
+      </DropdownButton>
+      <DropdownButton
+        type='button'
+        $active={status === 'REJECTED'}
+        onClick={() => {
+          setStatus('REJECTED');
+        }}
+      >
+        거절
+      </DropdownButton>
+      <DropdownButton
+        type='button'
+        $active={status === 'INTERVIEW_PENDING'}
+        onClick={() => {
+          setStatus('INTERVIEW_PENDING');
+        }}
+      >
+        면접 대기
+      </DropdownButton>
+      <DropdownButton
+        type='button'
+        $active={status === 'INTERVIEW_COMPLETED'}
+        onClick={() => {
+          setStatus('INTERVIEW_COMPLETED');
+        }}
+      >
+        면접 완료
+      </DropdownButton>
+      <DropdownButton
+        type='button'
+        $active={status === 'HIRED'}
+        onClick={() => {
+          setStatus('HIRED');
+        }}
+      >
+        채용 완료
+      </DropdownButton>
+    </>
+  );
+}

--- a/src/app/myAlbaform/applicant/components/statusSort/styles.ts
+++ b/src/app/myAlbaform/applicant/components/statusSort/styles.ts
@@ -1,0 +1,71 @@
+import { media } from '@/styles/media';
+import styled, { css } from 'styled-components';
+
+type DropdownProps = {
+  $active?: boolean;
+};
+
+type DropdownButtonProps = {
+  $active?: boolean;
+};
+
+export const DropdownContainer = styled.div<DropdownProps>`
+  position: absolute;
+  top: 130%;
+  left: 0;
+  z-index: 100;
+  opacity: 0;
+  transform: translateY(-10px);
+  pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+
+  ${({ $active }) =>
+    $active &&
+    css`
+      opacity: 1;
+      transform: translateY(0);
+      pointer-events: auto;
+    `}
+`;
+
+export const DropdownBox = styled.div`
+  padding: 7px;
+  background: var(--white);
+  border-radius: 8px;
+  border: 1px solid var(--line100);
+  box-shadow: 4px 4px 4px rgba(228, 228, 228, 0.1);
+  z-index: 100;
+  font-size: 16px;
+
+  @media ${media.tablet} {
+    font-size: 14px;
+  }
+`;
+
+export const DropdownButton = styled.button<DropdownButtonProps>`
+  width: 118px;
+  height: 38px;
+  margin-bottom: 7px;
+  border-radius: 8px;
+  text-align: center;
+  cursor: pointer;
+  transition: 0.2s;
+  font-weight: 400;
+  color: var(--gray400);
+
+  &:hover {
+    background: var(--primary-orange100);
+    color: var(--black400);
+  }
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+
+  ${({ $active }) =>
+    $active &&
+    css`
+      background: var(--primary-orange100);
+      color: var(--black400);
+    `}
+`;

--- a/src/app/myAlbaform/applicant/components/statusSort/type.ts
+++ b/src/app/myAlbaform/applicant/components/statusSort/type.ts
@@ -1,0 +1,15 @@
+import { Dispatch, SetStateAction } from 'react';
+
+export interface StatusDropdownProps {
+  status:
+    | ''
+    | 'REJECTED'
+    | 'INTERVIEW_PENDING'
+    | 'INTERVIEW_COMPLETED'
+    | 'HIRED';
+  setStatus: Dispatch<
+    SetStateAction<
+      '' | 'REJECTED' | 'INTERVIEW_PENDING' | 'INTERVIEW_COMPLETED' | 'HIRED'
+    >
+  >;
+}

--- a/src/app/myAlbaform/applicant/page.tsx
+++ b/src/app/myAlbaform/applicant/page.tsx
@@ -31,10 +31,12 @@ export default function myAlbaform() {
 
   return (
     <div className='h-[100%] bg-background-100'>
-      <div className='border-solid border-b-[1px] border-line-100'>
-        <FilterResponsive>
-          <FilterContainer setKeyword={setKeyword} />
-        </FilterResponsive>
+      <div className='border-solid border-b-[1px] border-line-100 bg-white'>
+        <div className='border-solid border-b-[1px] border-line-100'>
+          <FilterResponsive>
+            <FilterContainer setKeyword={setKeyword} />
+          </FilterResponsive>
+        </div>
         <SortResponsive>
           <StatusSortButton status={status} setStatus={setStatus} />
         </SortResponsive>

--- a/src/app/myAlbaform/applicant/page.tsx
+++ b/src/app/myAlbaform/applicant/page.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { getItemsPerPage } from '@/app/albatalk/utils/getItemsPerPage';
+import { useState } from 'react';
+import { FilterResponsive, ListResponsive, SortResponsive } from '../styles';
+import FilterContainer from './components/FilterContainer';
+import StatusSortButton from './components/statusSort/StatusSortButton';
+import { useMyApplications } from '@/hooks/query/useMyApplications';
+import { useInfiniteScroll } from '@/hooks/common/useInfiniteScroll';
+import ContentsList from './components/ContentsList';
+
+export default function myAlbaform() {
+  const [status, setStatus] = useState<
+    '' | 'REJECTED' | 'INTERVIEW_PENDING' | 'INTERVIEW_COMPLETED' | 'HIRED'
+  >('');
+  const [keyword, setKeyword] = useState('');
+
+  const itemsPerPage = getItemsPerPage();
+
+  const {
+    data: applicationsData,
+    hasNextPage,
+    fetchNextPage,
+    isLoading,
+    isFetchingNextPage,
+  } = useMyApplications(itemsPerPage, status, keyword);
+
+  const listData = applicationsData?.pages.flatMap((page) => page.result) ?? [];
+
+  const observerRef = useInfiniteScroll(hasNextPage!, fetchNextPage!);
+
+  return (
+    <div className='h-[100%] bg-background-100'>
+      <div className='border-solid border-b-[1px] border-line-100'>
+        <FilterResponsive>
+          <FilterContainer setKeyword={setKeyword} />
+        </FilterResponsive>
+        <SortResponsive>
+          <StatusSortButton status={status} setStatus={setStatus} />
+        </SortResponsive>
+      </div>
+      <ListResponsive>
+        <ContentsList
+          listData={listData}
+          isLoading={isLoading}
+          isFetchingNextPage={isFetchingNextPage}
+        />
+      </ListResponsive>
+      {hasNextPage && <div ref={observerRef} style={{ height: '1px' }} />}
+    </div>
+  );
+}

--- a/src/app/myAlbaform/owner/page.tsx
+++ b/src/app/myAlbaform/owner/page.tsx
@@ -1,0 +1,3 @@
+export default function myAlbaform() {
+  return <></>;
+}

--- a/src/app/myAlbaform/styles.ts
+++ b/src/app/myAlbaform/styles.ts
@@ -1,0 +1,126 @@
+import { media } from '@/styles/media';
+import styled from 'styled-components';
+
+export const FilterResponsive = styled.div`
+  position: relative;
+  padding: 112px 120px 24px;
+  border-bottom: 1px solid var(--line100);
+  background: var(--white);
+
+  @media ${media.desktop} {
+    padding: 112px 0 24px;
+    max-width: 1480px;
+    margin: 0 auto;
+  }
+
+  @media ${media.tabletPC} {
+    padding: 112px 24px 24px;
+    margin: 0;
+  }
+
+  @media ${media.tablet} {
+    padding: 78px 24px 16px;
+    margin: 0;
+  }
+
+  @media ${media.mobile} {
+    padding: 62px 24px 8px;
+  }
+`;
+
+export const SortResponsive = styled.div`
+  position: relative;
+  padding: 24px 120px;
+  background: var(--white);
+
+  @media ${media.desktop} {
+    padding: 24px 120px;
+    max-width: 1480px;
+    margin: 0 auto;
+  }
+
+  @media ${media.tabletPC} {
+    padding: 24px;
+    margin: 0;
+  }
+
+  @media ${media.tablet} {
+    padding: 16px 24px;
+    margin: 0;
+  }
+
+  @media ${media.mobile} {
+    padding: 8px 24px;
+  }
+`;
+
+export const ListResponsive = styled.div`
+  position: relative;
+  min-height: 100% - 202px;
+  padding: 24px 120px calc(env(safe-area-inset-bottom) + 62px);
+
+  @media ${media.desktop} {
+    padding: 24px 24px calc(env(safe-area-inset-bottom) + 62px);
+    max-width: 1480px;
+    margin: 0 auto;
+  }
+
+  @media ${media.tablet} {
+    padding: 16px 24px calc(env(safe-area-inset-bottom) + 62px);
+    margin: 0;
+  }
+
+  @media ${media.mobile} {
+    padding: 0 24px calc(env(safe-area-inset-bottom) + 62px);
+  }
+`;
+
+export const PostWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  min-width: 32%;
+  width: 32%;
+  padding: 24px;
+  position: relative;
+  border: 1px solid var(--line100);
+  border-radius: 16px;
+  box-shadow: 4px 4px 6px 0 rgba(212, 212, 212, 0.1);
+  cursor: pointer;
+  background: var(--white);
+
+  @media (max-width: 1450px) {
+    min-width: 49%;
+    width: 49%;
+  }
+
+  @media ${media.tabletPC} {
+    flex-direction: column;
+    width: 100%;
+    min-width: 100%;
+  }
+`;
+
+export const Title = styled.p`
+  text-overflow: ellipsis;
+  overflow: hidden;
+  word-break: break-word;
+  display: -webkit-inline-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  font-size: 18px;
+  font-weight: 500;
+`;
+
+export const Description = styled.p`
+  width: 85%;
+  margin-top: 10px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  word-break: break-word;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  font-weight: 300;
+  color: var(--gray500);
+`;

--- a/src/app/myAlbaform/styles.ts
+++ b/src/app/myAlbaform/styles.ts
@@ -4,7 +4,6 @@ import styled from 'styled-components';
 export const FilterResponsive = styled.div`
   position: relative;
   padding: 112px 120px 24px;
-  border-bottom: 1px solid var(--line100);
   background: var(--white);
 
   @media ${media.desktop} {
@@ -34,7 +33,7 @@ export const SortResponsive = styled.div`
   background: var(--white);
 
   @media ${media.desktop} {
-    padding: 24px 120px;
+    padding: 24px 0;
     max-width: 1480px;
     margin: 0 auto;
   }

--- a/src/app/myAlbaform/types.ts
+++ b/src/app/myAlbaform/types.ts
@@ -1,0 +1,36 @@
+import { Dispatch, SetStateAction } from 'react';
+
+export interface FilterContainerProps {
+  setKeyword: Dispatch<SetStateAction<string>>;
+}
+
+type OwnerData = {
+  imageUrl: string;
+  storeName: string;
+  id: number;
+};
+
+type FormData = {
+  owner: OwnerData;
+  recruitmentEndDate: string;
+  recruitmentStartDate: string;
+  description: string;
+  title: string;
+  id: number;
+};
+
+export interface ListData {
+  updatedAt: string;
+  createdAt: string;
+  status: string;
+  resumeName: string;
+  resumeId: number;
+  form: FormData;
+  id: number;
+}
+
+export interface ListContainerProps {
+  listData: ListData[];
+  isLoading: boolean;
+  isFetchingNextPage: boolean;
+}

--- a/src/hooks/query/useMyApplications.ts
+++ b/src/hooks/query/useMyApplications.ts
@@ -1,2 +1,20 @@
-// 내가 지원하 알바 목록 불러오기
+// 내가 지원한 알바 목록 불러오기
 // GET 'users/me/applications'
+
+import { fetchMyAppications } from "@/lib/fetch/user";
+import { useInfiniteQuery } from "@tanstack/react-query";
+
+export const useMyApplications = (
+  itemsPerPage: number,
+  status: '' | 'REJECTED' | 'INTERVIEW_PENDING' | 'INTERVIEW_COMPLETED' | 'HIRED',
+  keyword:string
+) => {
+  return useInfiniteQuery({
+    queryKey: ['myApplications', status, keyword],
+    queryFn: ({ pageParam = 1 }) =>
+      fetchMyAppications({ status, itemsPerPage, cursor: pageParam, keyword }),
+    getNextPageParam: (lastPage) => lastPage?.nextPage ?? undefined,
+    initialPageParam: 1,
+    staleTime: 1000 * 60,
+  });
+};

--- a/src/lib/fetch/user.ts
+++ b/src/lib/fetch/user.ts
@@ -77,14 +77,42 @@ export const fetchMyForms = async () => {
 };
 
 // 내가 지원한 알바폼 목록 조회
-export const fetchMyAppications = async () => {
+export const fetchMyAppications = async ({
+  status,
+  itemsPerPage,
+  cursor,
+  keyword,
+}: {
+  status:
+    | ''
+    | 'REJECTED'
+    | 'INTERVIEW_PENDING'
+    | 'INTERVIEW_COMPLETED'
+    | 'HIRED';
+  itemsPerPage: number;
+  cursor: number;
+  keyword: string;
+}) => {
   try {
-    const response = await instance.get('/users/me/applications');
+    const requestUrl =
+      cursor === 1
+        ? `/users/me/applications?limit=${itemsPerPage}${
+            status.length > 0 ? `&status=${status}` : ''
+          }&keyword=${keyword}`
+        : `/users/me/applications?limit=${itemsPerPage}${
+            status.length > 0 ? `&status=${status}` : ''
+          }&cursor=${cursor}&keyword=${keyword}`;
+
+    const response = await instance.get(requestUrl);
+
     if (!response.data) {
       throw new Error('내 지원서 데이터 불러오기 실패');
     }
-    const result = response.data;
-    return result;
+
+    return {
+      result: response.data.data,
+      nextPage: response.data.nextCursor,
+    };
   } catch (error) {
     console.error('내 지원서 데이터 불러오는 중 에러 발생:', error);
     throw error;
@@ -104,7 +132,7 @@ export const fetchMyScrap = async ({
   cursor: number;
   isPublic?: boolean;
   isRecruiting?: boolean;
-}):Promise<{result:ListData[]; nextPage:number}> => {
+}): Promise<{ result: ListData[]; nextPage: number }> => {
   try {
     const requestUrl =
       cursor === 1


### PR DESCRIPTION
## 🔗 관련 이슈
- Close #X

## 📌 PR 내용 요약
- 지원자의 내 알바폼 UIUX 및 API 연동 / 무한스크롤 모두 구현 완료

## ✨ 작업 내용
- 내 알바폼 페이지 UIUX
- API 연동
- 무한스크롤
- 검색 및 정렬

## 🔍 테스트 방법 (선택)
![화면 기록 2025-06-11 오후 4 49 53](https://github.com/user-attachments/assets/a145e426-9cb5-43c8-be79-7b89e5183964)

## ⚠️ 참고 및 공유 사항
- 모집 상태에 따라 UI적인 디자인을 다르게 출력하고 싶었으나 별도의 디자인 시안은 없어 시그니처 색상(오렌지)으로 통일 해두었습니다.
<img width="189" alt="스크린샷 2025-06-11 오후 4 44 15" src="https://github.com/user-attachments/assets/8ffc1a87-8b4e-4776-ab15-f034c010875c" />

