### PR TITLE
feat: 지원자 > 알바폼 상세 페이지 - 카카오 공유하기 연동

### DIFF
--- a/src/app/albaform/[id]/page.tsx
+++ b/src/app/albaform/[id]/page.tsx
@@ -9,15 +9,17 @@ import Toast from '@/components/tooltip/Toast';
 import FloatingButton from '@/components/floatingbutton/FloatingButton';
 import { useGetMyInfo } from '@/hooks/query/useGetUser';
 import Section3 from './components/section3/Section3';
-import { useParams } from 'next/navigation';
+import { useParams, usePathname } from 'next/navigation';
 import { useGetFormsById } from '@/hooks/query/useGetFormsById';
 import { useModalController } from '@/hooks/common/useModalController';
 import Modal from '@/components/modal/Modal';
 import Loader from '@/components/loader/Loader';
 import { useScrapForms } from '@/hooks/mutation/useScrapForms';
+import KakaoShareButton from '@/components/common/KakaoShareButton';
 
 export default function DetailPage() {
   const params = useParams();
+  const path = usePathname();
   const paramsId = Array.isArray(params.id) ? params.id[0] : params.id ?? '';
   const formId = Number(paramsId);
 
@@ -32,6 +34,13 @@ export default function DetailPage() {
   const { role, id: userId } = user ?? {};
 
   const myPost = userId === form?.ownerId;
+
+  const { handleShare } = KakaoShareButton({
+    url: path,
+    title: form?.title,
+    description: form?.description,
+    imageUrl: form?.imageUrls[0],
+  });
 
   const {
     showModal,
@@ -101,7 +110,9 @@ export default function DetailPage() {
       )}
       {showToast && (
         <Toast onClose={() => setShowToast(false)}>
-          {isScrapped ? '스크랩이 완료되었습니다 !' : '스크랩이 취소되었습니다 !'}
+          {isScrapped
+            ? '스크랩이 완료되었습니다 !'
+            : '스크랩이 취소되었습니다 !'}
         </Toast>
       )}
       <FloatingButton
@@ -110,6 +121,7 @@ export default function DetailPage() {
         isScrapped={isScrapped}
         handleToggleScrap={handleToggleScrap}
         postScrapPending={postScrapPending}
+        handleShare={handleShare}
       />
     </>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import ClientLayout from '@/app/ClientLayout';
 import '@/styles/tailwindStyle.css';
 import DaumPostcodeScript from '@/components/common/DaumPostcodeScript';
 import KakaoMapScript from '@/components/common/KakaoMapScript';
+import Script from 'next/script';
 
 export const metadata: Metadata = {
   title: 'Albaform',
@@ -22,6 +23,10 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         <meta
           name='viewport'
           content='width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no, viewport-fit=cover'
+        />
+        <Script
+          src='https://developers.kakao.com/sdk/js/kakao.js'
+          strategy='beforeInteractive'
         />
       </head>
       <body>

--- a/src/components/common/KakaoShareButton.tsx
+++ b/src/components/common/KakaoShareButton.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useEffect } from 'react';
+
+declare global {
+  interface Window {
+    Kakao: any;
+  }
+}
+
+export default function KakaoShareButton({
+  url,
+  title,
+  description,
+  imageUrl,
+}: {
+  url: string;
+  title: string;
+  description: string;
+  imageUrl: string;
+}) {
+  useEffect(() => {
+    if (
+      typeof window !== 'undefined' &&
+      window.Kakao &&
+      !window.Kakao.isInitialized()
+    ) {
+      window.Kakao.init('f67b2213023de6e332711e951c139bb5');
+    }
+  }, []);
+
+  const handleShare = () => {
+    if (!window.Kakao) return;
+
+    window.Kakao.Share.sendDefault({
+      objectType: 'feed',
+      content: {
+        title,
+        description,
+        imageUrl,
+        link: {
+          mobileWebUrl: url,
+          webUrl: url,
+        },
+      },
+      buttons: [
+        {
+          title: '공고 보러 가기',
+          link: {
+            mobileWebUrl: url,
+            webUrl: url,
+          },
+        },
+      ],
+    });
+  };
+
+  return { handleShare };
+}

--- a/src/components/floatingbutton/FloatingButton.tsx
+++ b/src/components/floatingbutton/FloatingButton.tsx
@@ -16,7 +16,7 @@ export default function FloatingButton({
   isScrapped?: boolean;
   handleToggleScrap?: () => void;
   postScrapPending?: boolean;
-  handleShare: () => void;
+  handleShare?: () => void;
 }) {
   const router = useRouter();
 

--- a/src/components/floatingbutton/FloatingButton.tsx
+++ b/src/components/floatingbutton/FloatingButton.tsx
@@ -8,6 +8,7 @@ export default function FloatingButton({
   isScrapped,
   handleToggleScrap,
   postScrapPending,
+  handleShare,
 }: {
   $myAlbaform?: boolean;
   $albaformDetail?: boolean;
@@ -15,10 +16,12 @@ export default function FloatingButton({
   isScrapped?: boolean;
   handleToggleScrap?: () => void;
   postScrapPending?: boolean;
+  handleShare: () => void;
 }) {
   const router = useRouter();
 
   if (role === 'OWNER') return;
+
   return (
     <>
       {role === 'APPLICANT' && $albaformDetail ? (
@@ -40,7 +43,10 @@ export default function FloatingButton({
               className='relative'
             />
           </button>
-          <button className='block rounded-[50%] bg-primary-orange300 w-[64px] h-[64px] content-center justify-items-center'>
+          <button
+            className='block rounded-[50%] bg-primary-orange300 w-[64px] h-[64px] content-center justify-items-center'
+            onClick={handleShare}
+          >
             <Image
               src='/images/floatingbutton/iconShare.svg'
               alt='공유하기'


### PR DESCRIPTION
## 🔗 관련 이슈
- Close #162 

## 📌 PR 내용 요약
- 지원자의 알바폼 상세 페이지에서 카카오 공유하기 API를 연동했습니다.

## ✨ 작업 내용
- 카카오 공유하기 API 연동

## 🔍 테스트 방법 (선택)
![화면 기록 2025-06-15 오후 3 58 54](https://github.com/user-attachments/assets/9a809dac-d858-42b2-9289-8217d9586ef8)

## ⚠️ 참고 및 공유 사항
