### PR TITLE
feat: 알바폼 리스트 / 내 알바폼 리스트 링크 연결 및 모집 마감 공고 '지원하기' 버튼 비활성화 처리

### DIFF
--- a/src/app/albaform/[id]/components/section2/BlockContainer.tsx
+++ b/src/app/albaform/[id]/components/section2/BlockContainer.tsx
@@ -4,6 +4,7 @@ import getDday from '@/utils/getDday';
 import { formattedDate } from '@/utils/formattedDate';
 import { Dispatch, SetStateAction } from 'react';
 import { useRouter } from 'next/navigation';
+import getRecruitStatus from '@/utils/getRecruitStatus';
 
 export default function BlockContainer({
   form,
@@ -41,6 +42,10 @@ export default function BlockContainer({
     setMainMessage('선택하신 알바폼을 삭제할까요?');
     setSubMessage('삭제 후 정보를 복구할 수 없어요.');
   };
+
+  const recruitmentDeadline =
+    getRecruitStatus(form?.recruitmentStartDate, form?.recruitmentEndDate) ===
+    '모집 마감';
 
   return (
     <>
@@ -99,7 +104,10 @@ export default function BlockContainer({
         >
           <button
             type='button'
-            className='flex items-center w-full h-[68px] bg-orange-400 rounded-[8px] justify-center text-white font-semibold'
+            className={`flex items-center w-full h-[68px] rounded-[8px] justify-center text-white font-semibold ${
+              recruitmentDeadline ? 'bg-gray-400' : 'bg-orange-400'
+            }`}
+            disabled={recruitmentDeadline}
           >
             <Image
               src={
@@ -110,9 +118,13 @@ export default function BlockContainer({
               alt='지원하기'
               width={24}
               height={24}
-              className='mr-1'
+              className={`mr-1 ${recruitmentDeadline && 'hidden'}`}
             />
-            {myPost ? '수정하기' : '지원하기'}
+            {myPost
+              ? '수정하기'
+              : recruitmentDeadline
+              ? '모집 마감'
+              : '지원하기'}
           </button>
           <button
             type='button'

--- a/src/app/albaform/components/ContentsList.tsx
+++ b/src/app/albaform/components/ContentsList.tsx
@@ -34,7 +34,10 @@ export default function ContentsList({
                 String(item.recruitmentEndDate),
               );
               return (
-                <FormWrapper key={item.id}>
+                <FormWrapper
+                  key={item.id}
+                  onClick={() => router.push(`/albaform/${item.id}`)}
+                >
                   <div
                     className='relative w-full h-[calc(100vw_*_(304/1920))] border border-solid border-gray-100 rounded-[16px] min-h-[304px] overflow-hidden'
                     style={{

--- a/src/app/myAlbaform/owner/components/ContentsList.tsx
+++ b/src/app/myAlbaform/owner/components/ContentsList.tsx
@@ -40,7 +40,13 @@ export default function ContentsList({
                 String(item.recruitmentEndDate),
               );
               return (
-                <FormWrapper key={item.id}>
+                <FormWrapper
+                  $noActive={!item.isPublic}
+                  key={item.id}
+                  onClick={() =>
+                    item.isPublic && router.push(`/albaform/${item.id}`)
+                  }
+                >
                   <div
                     className='relative w-full h-[calc(100vw_*_(304/1920))] border border-solid border-gray-100 rounded-[16px] min-h-[304px] overflow-hidden'
                     style={{

--- a/src/app/myAlbaform/styles.ts
+++ b/src/app/myAlbaform/styles.ts
@@ -13,6 +13,10 @@ type DropdownButtonProps = {
   $active?: boolean;
 };
 
+type FormWrapperProps = {
+  $noActive?: boolean;
+};
+
 export const KebabButton = styled.div`
   min-width: 36px;
   margin-top: -3px;
@@ -127,14 +131,14 @@ export const PostWrapper = styled.div`
   }
 `;
 
-export const FormWrapper = styled.div`
+export const FormWrapper = styled.div<FormWrapperProps>`
   display: flex;
   flex-direction: column;
   justify-content: space-between;
   min-width: 32%;
   width: 32%;
   position: relative;
-  cursor: pointer;
+  cursor: ${({ $noActive }) => ($noActive ? 'default' : 'pointer')};
 
   @media (max-width: 1450px) {
     min-width: 49%;


### PR DESCRIPTION
## 🔗 관련 이슈
- Close #X

## 📌 PR 내용 요약
- 링크 연결 및 모집 마감 공고 '지원하기' 버튼 비활성화

## ✨ 작업 내용
- 알바폼 리스트 > 상세페이지 링크 연결
- 내 알바폼 리스트 > 상세페이지 링크 연결
- 지원자 - 알바폼 상세 페이지 모집 마감 시 '지원하기' 버튼 비활성화

## 🔍 테스트 방법 (선택)

## ⚠️ 참고 및 공유 사항
