### PR TITLE
feat: 지원자 > 알바폼 지원하기 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "jotai": "^2.12.5",
         "js-cookie": "^3.0.5",
         "lucide-react": "^0.508.0",
-        "next": "15.3.1",
+        "next": "^15.3.4",
         "react": "^19.0.0",
         "react-datepicker": "^8.3.0",
         "react-dom": "^19.0.0",
@@ -2912,9 +2912,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.3.1",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.3.1.tgz",
-      "integrity": "sha512-cwK27QdzrMblHSn9DZRV+DQscHXRuJv6MydlJRpFSqJWZrTYMLzKDeyueJNN9MGd8NNiUKzDQADAf+dMLXX7YQ==",
+      "version": "15.3.4",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.3.4.tgz",
+      "integrity": "sha512-ZkdYzBseS6UjYzz6ylVKPOK+//zLWvD6Ta+vpoye8cW11AjiQjGYVibF0xuvT4L0iJfAPfZLFidaEzAOywyOAQ==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -2928,9 +2928,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.3.1.tgz",
-      "integrity": "sha512-hjDw4f4/nla+6wysBL07z52Gs55Gttp5Bsk5/8AncQLJoisvTBP0pRIBK/B16/KqQyH+uN4Ww8KkcAqJODYH3w==",
+      "version": "15.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.3.4.tgz",
+      "integrity": "sha512-z0qIYTONmPRbwHWvpyrFXJd5F9YWLCsw3Sjrzj2ZvMYy9NPQMPZ1NjOJh4ojr4oQzcGYwgJKfidzehaNa1BpEg==",
       "cpu": [
         "arm64"
       ],
@@ -2944,9 +2944,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.3.1.tgz",
-      "integrity": "sha512-q+aw+cJ2ooVYdCEqZVk+T4Ni10jF6Fo5DfpEV51OupMaV5XL6pf3GCzrk6kSSZBsMKZtVC1Zm/xaNBFpA6bJ2g==",
+      "version": "15.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.3.4.tgz",
+      "integrity": "sha512-Z0FYJM8lritw5Wq+vpHYuCIzIlEMjewG2aRkc3Hi2rcbULknYL/xqfpBL23jQnCSrDUGAo/AEv0Z+s2bff9Zkw==",
       "cpu": [
         "x64"
       ],
@@ -2960,9 +2960,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.3.1.tgz",
-      "integrity": "sha512-wBQ+jGUI3N0QZyWmmvRHjXjTWFy8o+zPFLSOyAyGFI94oJi+kK/LIZFJXeykvgXUk1NLDAEFDZw/NVINhdk9FQ==",
+      "version": "15.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.3.4.tgz",
+      "integrity": "sha512-l8ZQOCCg7adwmsnFm8m5q9eIPAHdaB2F3cxhufYtVo84pymwKuWfpYTKcUiFcutJdp9xGHC+F1Uq3xnFU1B/7g==",
       "cpu": [
         "arm64"
       ],
@@ -2976,9 +2976,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.3.1.tgz",
-      "integrity": "sha512-IIxXEXRti/AulO9lWRHiCpUUR8AR/ZYLPALgiIg/9ENzMzLn3l0NSxVdva7R/VDcuSEBo0eGVCe3evSIHNz0Hg==",
+      "version": "15.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.3.4.tgz",
+      "integrity": "sha512-wFyZ7X470YJQtpKot4xCY3gpdn8lE9nTlldG07/kJYexCUpX1piX+MBfZdvulo+t1yADFVEuzFfVHfklfEx8kw==",
       "cpu": [
         "arm64"
       ],
@@ -2992,9 +2992,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.3.1.tgz",
-      "integrity": "sha512-bfI4AMhySJbyXQIKH5rmLJ5/BP7bPwuxauTvVEiJ/ADoddaA9fgyNNCcsbu9SlqfHDoZmfI6g2EjzLwbsVTr5A==",
+      "version": "15.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.3.4.tgz",
+      "integrity": "sha512-gEbH9rv9o7I12qPyvZNVTyP/PWKqOp8clvnoYZQiX800KkqsaJZuOXkWgMa7ANCCh/oEN2ZQheh3yH8/kWPSEg==",
       "cpu": [
         "x64"
       ],
@@ -3008,9 +3008,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.3.1.tgz",
-      "integrity": "sha512-FeAbR7FYMWR+Z+M5iSGytVryKHiAsc0x3Nc3J+FD5NVbD5Mqz7fTSy8CYliXinn7T26nDMbpExRUI/4ekTvoiA==",
+      "version": "15.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.3.4.tgz",
+      "integrity": "sha512-Cf8sr0ufuC/nu/yQ76AnarbSAXcwG/wj+1xFPNbyNo8ltA6kw5d5YqO8kQuwVIxk13SBdtgXrNyom3ZosHAy4A==",
       "cpu": [
         "x64"
       ],
@@ -3024,9 +3024,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.3.1.tgz",
-      "integrity": "sha512-yP7FueWjphQEPpJQ2oKmshk/ppOt+0/bB8JC8svPUZNy0Pi3KbPx2Llkzv1p8CoQa+D2wknINlJpHf3vtChVBw==",
+      "version": "15.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.3.4.tgz",
+      "integrity": "sha512-ay5+qADDN3rwRbRpEhTOreOn1OyJIXS60tg9WMYTWCy3fB6rGoyjLVxc4dR9PYjEdR2iDYsaF5h03NA+XuYPQQ==",
       "cpu": [
         "arm64"
       ],
@@ -3040,9 +3040,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.3.1.tgz",
-      "integrity": "sha512-3PMvF2zRJAifcRNni9uMk/gulWfWS+qVI/pagd+4yLF5bcXPZPPH2xlYRYOsUjmCJOXSTAC2PjRzbhsRzR2fDQ==",
+      "version": "15.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.3.4.tgz",
+      "integrity": "sha512-4kDt31Bc9DGyYs41FTL1/kNpDeHyha2TC0j5sRRoKCyrhNcfZ/nRQkAUlF27mETwm8QyHqIjHJitfcza2Iykfg==",
       "cpu": [
         "x64"
       ],
@@ -13520,12 +13520,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "15.3.1",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.3.1.tgz",
-      "integrity": "sha512-8+dDV0xNLOgHlyBxP1GwHGVaNXsmp+2NhZEYrXr24GWLHtt27YrBPbPuHvzlhi7kZNYjeJNR93IF5zfFu5UL0g==",
+      "version": "15.3.4",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.3.4.tgz",
+      "integrity": "sha512-mHKd50C+mCjam/gcnwqL1T1vPx/XQNFlXqFIVdgQdVAFY9iIQtY0IfaVflEYzKiqjeA7B0cYYMaCrmAYFjs4rA==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.3.1",
+        "@next/env": "15.3.4",
         "@swc/counter": "0.1.3",
         "@swc/helpers": "0.5.15",
         "busboy": "1.6.0",
@@ -13540,14 +13540,14 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.3.1",
-        "@next/swc-darwin-x64": "15.3.1",
-        "@next/swc-linux-arm64-gnu": "15.3.1",
-        "@next/swc-linux-arm64-musl": "15.3.1",
-        "@next/swc-linux-x64-gnu": "15.3.1",
-        "@next/swc-linux-x64-musl": "15.3.1",
-        "@next/swc-win32-arm64-msvc": "15.3.1",
-        "@next/swc-win32-x64-msvc": "15.3.1",
+        "@next/swc-darwin-arm64": "15.3.4",
+        "@next/swc-darwin-x64": "15.3.4",
+        "@next/swc-linux-arm64-gnu": "15.3.4",
+        "@next/swc-linux-arm64-musl": "15.3.4",
+        "@next/swc-linux-x64-gnu": "15.3.4",
+        "@next/swc-linux-x64-musl": "15.3.4",
+        "@next/swc-win32-arm64-msvc": "15.3.4",
+        "@next/swc-win32-x64-msvc": "15.3.4",
         "sharp": "^0.34.1"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "jotai": "^2.12.5",
     "js-cookie": "^3.0.5",
     "lucide-react": "^0.508.0",
-    "next": "15.3.1",
+    "next": "^15.3.4",
     "react": "^19.0.0",
     "react-datepicker": "^8.3.0",
     "react-dom": "^19.0.0",

--- a/public/images/createAlbaform/iconUpload.svg
+++ b/public/images/createAlbaform/iconUpload.svg
@@ -1,0 +1,5 @@
+<svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M13 14L18 9L23 14" stroke="black" stroke-width="2" stroke-linecap="round"/>
+<path d="M18 9V22" stroke="black" stroke-width="2" stroke-linecap="round"/>
+<path d="M11 27H25" stroke="black" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/src/app/albaform/ClientAlbaform.tsx
+++ b/src/app/albaform/ClientAlbaform.tsx
@@ -39,7 +39,6 @@ export default function ClientAlbaform({
   );
 
   const { data: user, isLoading: getUserLoading } = useGetMyInfo();
-  const { role } = user ?? {};
 
   const isLoading = getAlbaformsLoading || getUserLoading;
 

--- a/src/app/albaform/ClientAlbaform.tsx
+++ b/src/app/albaform/ClientAlbaform.tsx
@@ -10,6 +10,7 @@ import FloatingButton from '@/components/floatingbutton/FloatingButton';
 import { useInfiniteScroll } from '@/hooks/common/useInfiniteScroll';
 import { useAlbaForms } from '@/hooks/query/useGetForms';
 import { ClientAlbaformProps } from './types';
+import { useGetMyInfo } from '@/hooks/query/useGetUser';
 
 export default function ClientAlbaform({
   initialParams,
@@ -24,8 +25,23 @@ export default function ClientAlbaform({
   );
   const [keyword, setKeyword] = useState(initialParams.keyword);
 
-  const { data, isLoading, isFetchingNextPage, fetchNextPage, hasNextPage } =
-    useAlbaForms(initialParams.itemsPerPage, postSort, recruitingSort, keyword);
+  const {
+    data,
+    isLoading: getAlbaformsLoading,
+    isFetchingNextPage,
+    fetchNextPage,
+    hasNextPage,
+  } = useAlbaForms(
+    initialParams.itemsPerPage,
+    postSort,
+    recruitingSort,
+    keyword,
+  );
+
+  const { data: user, isLoading: getUserLoading } = useGetMyInfo();
+  const { role } = user ?? {};
+
+  const isLoading = getAlbaformsLoading || getUserLoading;
 
   const listData = data?.pages.flatMap((page) => page.result) ?? [];
 
@@ -62,7 +78,7 @@ export default function ClientAlbaform({
         </SortResponsive>
         {hasNextPage && <div ref={observerRef} style={{ height: 1 }} />}
       </div>
-      <FloatingButton $myAlbaform />
+      {user?.role === 'OWNER' && !isLoading && <FloatingButton $myAlbaform />}
     </>
   );
 }

--- a/src/app/albaform/[id]/components/constants/recruitmentItems.ts
+++ b/src/app/albaform/[id]/components/constants/recruitmentItems.ts
@@ -1,0 +1,22 @@
+export const RECRUIMENT_ITMES = [
+  {
+    condition: '모집인원',
+    formValue: 'numberOfPositions',
+  },
+  {
+    condition: '성별',
+    formValue: 'gender',
+  },
+  {
+    condition: '학력',
+    formValue: 'education',
+  },
+  {
+    condition: '연령',
+    formValue: 'age',
+  },
+  {
+    condition: '우대사항',
+    formValue: 'preferred',
+  },
+];

--- a/src/app/albaform/[id]/components/section1/BlockContainer.tsx
+++ b/src/app/albaform/[id]/components/section1/BlockContainer.tsx
@@ -50,7 +50,8 @@ export default function BlockContainer({
               기간
             </p>
             <p className='text-[20px] text-orange-400 font-semibold max-lg:text-[14px]'>
-              {formattedDate(form?.workStartDate)} ~{' '}
+              {formattedDate(form?.workStartDate)} ~
+              <br className='max-lg:hidden' />{' '}
               {formattedDate(form?.workEndDate)}
             </p>
           </div>

--- a/src/app/albaform/[id]/components/section1/TextContainer.tsx
+++ b/src/app/albaform/[id]/components/section1/TextContainer.tsx
@@ -35,7 +35,7 @@ export default function TextContainer({ form }: { form: DetailFormDataProps }) {
       </div>
       <div>
         <div className='flex items-center mb-4'>
-          <p className='text-black-400 underline font-semibold mr-4 text-[24px] max-md:text-[18px]'>
+          <p className='min-w-max text-black-400 underline font-semibold mr-4 text-[24px] max-md:text-[18px]'>
             {form?.storeName}
           </p>
           <p className='text-gray-400 text-[20px] max-md:text-[16px]'>

--- a/src/app/albaform/[id]/components/section2/BlockContainer.tsx
+++ b/src/app/albaform/[id]/components/section2/BlockContainer.tsx
@@ -1,12 +1,12 @@
-import Image from 'next/image';
 import { DetailFormDataProps } from '../../types';
 import getDday from '@/utils/getDday';
 import { formattedDate } from '@/utils/formattedDate';
 import { Dispatch, SetStateAction } from 'react';
-import { useRouter } from 'next/navigation';
-import getRecruitStatus from '@/utils/getRecruitStatus';
+import ButtonContainer from './ButtonContainer';
+import { RECRUIMENT_ITMES } from '../constants/recruitmentItems';
 
 export default function BlockContainer({
+  formId,
   form,
   role,
   isLoading,
@@ -16,6 +16,7 @@ export default function BlockContainer({
   setSubMessage,
   setModalType,
 }: {
+  formId: number;
   form: DetailFormDataProps;
   role: 'OWNER' | 'APPLICANT';
   isLoading: boolean;
@@ -34,45 +35,25 @@ export default function BlockContainer({
     >
   >;
 }) {
-  const router = useRouter();
-
-  const handleDeleteOpenModal = () => {
-    setShowModal(true);
-    setModalType('deleteForms');
-    setMainMessage('선택하신 알바폼을 삭제할까요?');
-    setSubMessage('삭제 후 정보를 복구할 수 없어요.');
-  };
-
-  const recruitmentDeadline =
-    getRecruitStatus(form?.recruitmentStartDate, form?.recruitmentEndDate) ===
-    '모집 마감';
-
   return (
     <>
       <p className='text-3xl font-semibold mb-10'>모집 조건</p>
       <div className='border border-solid border-line-100 rounded-[8px] bg-background-100 p-6'>
-        <div className='flex font-light'>
-          <p className='flex-[1] text-black200'>모집인원</p>
-          <p className='flex-[5] text-black400 ml-1'>
-            {form?.numberOfPositions}명
-          </p>
-        </div>
-        <div className='flex font-light mt-4'>
-          <p className='flex-[1] text-black200'>성별</p>
-          <p className='flex-[5] text-black400 ml-1'>{form?.gender}</p>
-        </div>
-        <div className='flex font-light mt-4'>
-          <p className='flex-[1] text-black200'>학력</p>
-          <p className='flex-[5] text-black400 ml-1'>{form?.education}</p>
-        </div>
-        <div className='flex font-light mt-4'>
-          <p className='flex-[1] text-black200'>연령</p>
-          <p className='flex-[5] text-black400 ml-1'>{form?.age}</p>
-        </div>
-        <div className='flex font-light mt-4'>
-          <p className='flex-[1] text-black200'>우대사항</p>
-          <p className='flex-[5] text-black400 ml-1'>{form?.preferred}</p>
-        </div>
+        {RECRUIMENT_ITMES.map((item, i) => {
+          return (
+            <div
+              key={i}
+              className={`flex font-light ${
+                item.condition !== '모집인원' && 'mt-4'
+              }`}
+            >
+              <p className='flex-[1] text-black200'>{item.condition}</p>
+              <p className='flex-[5] text-black400 ml-1'>
+                {form && form[item.formValue as keyof DetailFormDataProps]}
+              </p>
+            </div>
+          );
+        })}
       </div>
       <div className='border border-solid border-line-100 rounded-[8px] bg-background-100 p-6 mt-6'>
         <div className='flex justify-between font-light'>
@@ -97,64 +78,15 @@ export default function BlockContainer({
         </div>
       </div>
       {((!isLoading && role === 'APPLICANT') || (!isLoading && myPost)) && (
-        <div
-          className={`mt-[46px] left-[0] right-[0] bottom-[0] rounded-t-lg border-t border-solid border-line-200 max-lg:fixed max-lg:bg-white max-lg:pt-[20px] max-lg:px-6 max-lg:pb-[calc(30px+theme(spacing.safe-bottom))] z-[10] ${
-            myPost && 'max-lg:flex max-lg:flex-row-reverse'
-          }`}
-        >
-          <button
-            type='button'
-            className={`flex items-center w-full h-[68px] rounded-[8px] justify-center text-white font-semibold ${
-              recruitmentDeadline ? 'bg-gray-400' : 'bg-orange-400'
-            }`}
-            disabled={recruitmentDeadline}
-          >
-            <Image
-              src={
-                myPost
-                  ? '/images/albaformDetail/buttonEdit.svg'
-                  : '/images/albaformDetail/buttonWriting.svg'
-              }
-              alt='지원하기'
-              width={24}
-              height={24}
-              className={`mr-1 ${recruitmentDeadline && 'hidden'}`}
-            />
-            {myPost
-              ? '수정하기'
-              : recruitmentDeadline
-              ? '모집 마감'
-              : '지원하기'}
-          </button>
-          <button
-            type='button'
-            className={`flex items-center w-full h-[68px] border border-solid font-semibold rounded-[8px] mt-4 justify-center ${
-              myPost
-                ? 'border-[0] bg-line-200 text-gray-400 max-lg:mt-[0] max-lg:mr-2 max-lg:max-w-[70px]'
-                : 'border-orange-400 text-orange-400'
-            }`}
-            onClick={() =>
-              myPost
-                ? handleDeleteOpenModal()
-                : router.push('/myAlbaform/applicant')
-            }
-          >
-            <Image
-              src={
-                myPost
-                  ? '/images/albaformDetail/buttonTrash.svg'
-                  : '/images/albaformDetail/buttonApplyList.svg'
-              }
-              alt='내역보기'
-              width={24}
-              height={24}
-              className='mr-1'
-            />
-            <p className={`${myPost && 'max-lg:hidden'}`}>
-              {myPost ? '삭제하기' : '내 지원 내역 보기'}
-            </p>
-          </button>
-        </div>
+        <ButtonContainer
+          formId={formId}
+          form={form}
+          myPost={myPost}
+          setShowModal={setShowModal}
+          setMainMessage={setMainMessage}
+          setSubMessage={setSubMessage}
+          setModalType={setModalType}
+        />
       )}
     </>
   );

--- a/src/app/albaform/[id]/components/section2/ButtonContainer.tsx
+++ b/src/app/albaform/[id]/components/section2/ButtonContainer.tsx
@@ -1,0 +1,108 @@
+import getRecruitStatus from '@/utils/getRecruitStatus';
+import { SetStateAction } from 'jotai';
+import Image from 'next/image';
+import { useRouter } from 'next/navigation';
+import { Dispatch } from 'react';
+import { DetailFormDataProps } from '../../types';
+
+export default function ButtonContainer({
+  formId,
+  form,
+  myPost,
+  setShowModal,
+  setMainMessage,
+  setSubMessage,
+  setModalType,
+}: {
+  formId: number;
+  form: DetailFormDataProps;
+  myPost: boolean;
+  setShowModal: Dispatch<SetStateAction<boolean>>;
+  setMainMessage: Dispatch<SetStateAction<string>>;
+  setSubMessage: Dispatch<SetStateAction<string>>;
+  setModalType: Dispatch<
+    SetStateAction<
+      | 'editUser'
+      | 'editPassword'
+      | 'deletePost'
+      | 'deleteComment'
+      | 'cancelScrap'
+      | 'deleteForms'
+    >
+  >;
+}) {
+  const router = useRouter();
+
+  const handleDeleteOpenModal = () => {
+    setShowModal(true);
+    setModalType('deleteForms');
+    setMainMessage('선택하신 알바폼을 삭제할까요?');
+    setSubMessage('삭제 후 정보를 복구할 수 없어요.');
+  };
+
+  const recruitmentDeadline =
+    getRecruitStatus(form?.recruitmentStartDate, form?.recruitmentEndDate) ===
+    '모집 마감';
+
+  return (
+    <div
+      className={`mt-[46px] left-[0] right-[0] bottom-[0] rounded-t-lg border-t border-solid border-line-200 max-lg:fixed max-lg:bg-white max-lg:pt-[20px] max-lg:px-6 max-lg:pb-[calc(30px+theme(spacing.safe-bottom))] z-[10] ${
+        myPost && 'max-lg:flex max-lg:flex-row-reverse'
+      }`}
+    >
+      <button
+        type='button'
+        className={`flex items-center w-full h-[68px] rounded-[8px] justify-center text-white font-semibold ${
+          recruitmentDeadline ? 'bg-gray-400' : 'bg-orange-400'
+        }`}
+        disabled={recruitmentDeadline}
+        onClick={() => {
+          router.push(
+            myPost ? `` : `/createAlbaform/applicant?formId=${formId}`,
+          );
+        }}
+      >
+        <Image
+          src={
+            myPost
+              ? '/images/albaformDetail/buttonEdit.svg'
+              : '/images/albaformDetail/buttonWriting.svg'
+          }
+          alt='지원하기'
+          width={24}
+          height={24}
+          className={`mr-1 ${recruitmentDeadline && 'hidden'}`}
+        />
+        {myPost ? '수정하기' : recruitmentDeadline ? '모집 마감' : '지원하기'}
+      </button>
+      <button
+        type='button'
+        className={`flex items-center w-full h-[68px] border border-solid font-semibold rounded-[8px] mt-4 justify-center ${
+          myPost
+            ? 'border-[0] bg-line-200 text-gray-400 max-lg:mt-[0] max-lg:mr-2 max-lg:max-w-[70px]'
+            : 'border-orange-400 text-orange-400'
+        }`}
+        onClick={() =>
+          myPost
+            ? handleDeleteOpenModal()
+            : router.push('/myAlbaform/applicant')
+        }
+      >
+        <Image
+          src={
+            myPost
+              ? '/images/albaformDetail/buttonTrash.svg'
+              : '/images/albaformDetail/buttonApplyList.svg'
+          }
+          alt='내역보기'
+          width={24}
+          height={24}
+          className='mr-1'
+        />
+        <p className={`${myPost && 'max-lg:hidden'}`}>
+          {myPost ? '삭제하기' : '내 지원 내역 보기'}
+        </p>
+      </button>
+    </div>
+  );
+}

--- a/src/app/albaform/[id]/components/section2/Section2.tsx
+++ b/src/app/albaform/[id]/components/section2/Section2.tsx
@@ -6,6 +6,7 @@ import { DetailFormDataProps } from '../../types';
 
 export default function Section2({
   form,
+  formId,
   setCopied,
   role,
   isLoading,
@@ -16,6 +17,7 @@ export default function Section2({
   setModalType,
 }: {
   form: DetailFormDataProps;
+  formId: number;
   setCopied: Dispatch<SetStateAction<boolean>>;
   role: 'OWNER' | 'APPLICANT';
   isLoading: boolean;
@@ -43,6 +45,7 @@ export default function Section2({
       </div>
       <div className='flex-[1] max-lg:w-full max-lg:mt-20'>
         <BlockContainer
+          formId={formId}
           role={role}
           isLoading={isLoading}
           myPost={myPost}

--- a/src/app/albaform/[id]/components/section3/Section3.tsx
+++ b/src/app/albaform/[id]/components/section3/Section3.tsx
@@ -117,16 +117,18 @@ export default function Section3({ formId }: { formId: number }) {
               </tbody>
             </table>
           ) : (
-            <div className='flex flex-col items-center justify-center text-gray-400 mt-[50px] mb-[30px]'>
-              <Image
-                src='/images/empty/albaform.svg'
-                alt='Loading...'
-                width={80}
-                height={80}
-                className='mb-3'
-              />
-              아직 아무도 지원하지 않았어요
-            </div>
+            !isLoading && (
+              <div className='flex flex-col items-center justify-center text-gray-400 mt-[50px] mb-[30px]'>
+                <Image
+                  src='/images/empty/albaform.svg'
+                  alt='Loading...'
+                  width={80}
+                  height={80}
+                  className='mb-3'
+                />
+                아직 아무도 지원하지 않았어요
+              </div>
+            )
           )}
         </div>
         {(isLoading || isFetchingNextPage) && (

--- a/src/app/albaform/[id]/page.tsx
+++ b/src/app/albaform/[id]/page.tsx
@@ -95,6 +95,7 @@ export default function DetailPage() {
         <Section1 form={form} />
         <Section2
           form={form}
+          formId={formId}
           setCopied={setCopied}
           role={role}
           isLoading={getUserLoading}

--- a/src/app/albaform/[id]/styles.ts
+++ b/src/app/albaform/[id]/styles.ts
@@ -93,8 +93,8 @@ export const DetailResponsive = styled.div<DetailResponsiveProps>`
   @media ${media.mobile} {
     padding: ${({ $owner }) =>
       $owner
-        ? '0 24px calc(env(safe-area-inset-bottom) + 62px)'
-        : '0 24px calc(env(safe-area-inset-bottom) + 262px)'};
+        ? '16px 24px calc(env(safe-area-inset-bottom) + 62px)'
+        : '16px 24px calc(env(safe-area-inset-bottom) + 262px)'};
   }
 `;
 

--- a/src/app/albatalk/[id]/edit/components/HeadContainer.tsx
+++ b/src/app/albatalk/[id]/edit/components/HeadContainer.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from 'next/navigation';
-import { FormLogisProps } from '../../../types';
+import { FormLogicsProps } from '../../../types';
 
-export default function HeadContainer(props: FormLogisProps) {
+export default function HeadContainer(props: FormLogicsProps) {
   const router = useRouter();
 
   const { form, isModified, isPending } = props;

--- a/src/app/albatalk/[id]/edit/components/PostFormInputs.tsx
+++ b/src/app/albatalk/[id]/edit/components/PostFormInputs.tsx
@@ -1,8 +1,8 @@
 import useChangeProfilePreview from '@/hooks/common/useChangeProfilePreview';
 import Image from 'next/image';
-import { FormLogisProps } from '../../../types';
+import { FormLogicsProps } from '../../../types';
 
-export default function PostFormInputs(props: FormLogisProps) {
+export default function PostFormInputs(props: FormLogicsProps) {
   const { form, postByIdData, setSelectedImageFile } = props;
 
   const { register, formState, setValue, trigger } = form;

--- a/src/app/albatalk/new/components/HeadContainer.tsx
+++ b/src/app/albatalk/new/components/HeadContainer.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from 'next/navigation';
-import { FormLogisProps } from '../../types';
+import { FormLogicsProps } from '../../types';
 
-export default function HeadContainer(props: FormLogisProps) {
+export default function HeadContainer(props: FormLogicsProps) {
   const router = useRouter();
 
   const { form, isPending } = props;

--- a/src/app/albatalk/new/components/PostFormInputs.tsx
+++ b/src/app/albatalk/new/components/PostFormInputs.tsx
@@ -1,8 +1,8 @@
 import useChangeProfilePreview from '@/hooks/common/useChangeProfilePreview';
 import Image from 'next/image';
-import { FormLogisProps } from '../../types';
+import { FormLogicsProps } from '../../types';
 
-export default function PostFormInputs(props: FormLogisProps) {
+export default function PostFormInputs(props: FormLogicsProps) {
   const { form, setSelectedImageFile } = props;
 
   const { register, formState, setValue, trigger } = form;

--- a/src/app/albatalk/types.ts
+++ b/src/app/albatalk/types.ts
@@ -1,6 +1,6 @@
 import { AlbatalkInput } from '@/schemas/albatalkSchema';
 import { Dispatch, SetStateAction } from 'react';
-import { FieldValues } from 'react-hook-form';
+import { FieldValues, UseFormReturn } from 'react-hook-form';
 
 export interface FilterContainerProps {
   isSort: 'mostRecent' | 'mostCommented' | 'mostLiked';
@@ -40,8 +40,8 @@ export interface ListContainerProps {
   isFetchingNextPage: boolean;
 }
 
-export interface FormLogisProps {
-  form: FieldValues;
+export interface FormLogicsProps {
+  form: UseFormReturn<AlbatalkInput>;
   postByIdData?: ListData;
   isModified?: boolean;
   isPending?: boolean;

--- a/src/app/applications/[id]/components/section1/StatusContainer.tsx
+++ b/src/app/applications/[id]/components/section1/StatusContainer.tsx
@@ -1,4 +1,5 @@
 import { DetailFormDataProps } from '@/app/albaform/[id]/types';
+import Tooltip from '@/components/tooltip/ToolTip';
 import { formattedDate } from '@/utils/formattedDate';
 import getDday from '@/utils/getDday';
 import Image from 'next/image';
@@ -64,17 +65,8 @@ export default function StatusContainer({
             : ''}
         </p>
         {ownerType && (
-          <div className='absolute left-0 bottom-[-50px] pl-3 pr-4 h-10 leading-10 rounded-[14px] bg-primary-blue300 hidden text-white text-[14px] group-hover:block'>
-            <div className='flex item-center'>
-              <Image
-                src='/images/applicationDetail/iconInfo.svg'
-                alt='!'
-                width={24}
-                height={24}
-                className='mr-1'
-              />
-              <p>알바폼 현재 진행상태를 변경할 수 있어요!</p>
-            </div>
+          <div className='absolute left-0 bottom-[-80px] hidden text-white text-[14px] group-hover:block'>
+            <Tooltip>알바폼 현재 진행상태를 변경할 수 있어요!</Tooltip>
           </div>
         )}
       </div>

--- a/src/app/createAlbaform/applicant/components/ButtonContainer.tsx
+++ b/src/app/createAlbaform/applicant/components/ButtonContainer.tsx
@@ -1,4 +1,11 @@
-export default function ButtonContainer() {
+import Image from 'next/image';
+import { ApplyFormLogicsProps } from '../../types';
+
+export default function ButtonContainer(props: ApplyFormLogicsProps) {
+  const { form, isPending } = props;
+  const { formState } = form;
+  const { isValid } = formState;
+
   return (
     <div className='flex items-center gap-x-2'>
       <button
@@ -7,8 +14,20 @@ export default function ButtonContainer() {
       >
         임시 저장
       </button>
-      <button className='flex-[1] h-14 px-6 text-center bg-orange-400 text-white rounded-[8px] disabled:bg-gray-300'>
-        작성 완료
+      <button
+        className='flex-[1] h-14 px-6 text-center bg-orange-400 text-white rounded-[8px] disabled:bg-gray-300 disabled:cursor-not-allowed text-center justify-items-center'
+        disabled={!isValid || isPending}
+      >
+        {isPending ? (
+          <Image
+            src='/images/buttonLoader.gif'
+            alt='Loading'
+            width={50}
+            height={20}
+          />
+        ) : (
+          '작성 완료'
+        )}
       </button>
     </div>
   );

--- a/src/app/createAlbaform/applicant/components/ButtonContainer.tsx
+++ b/src/app/createAlbaform/applicant/components/ButtonContainer.tsx
@@ -7,7 +7,7 @@ export default function ButtonContainer() {
       >
         임시 저장
       </button>
-      <button className='flex-[1] h-14 px-6 text-center bg-gray-300 text-white rounded-[8px]'>
+      <button className='flex-[1] h-14 px-6 text-center bg-orange-400 text-white rounded-[8px] disabled:bg-gray-300'>
         작성 완료
       </button>
     </div>

--- a/src/app/createAlbaform/applicant/components/ButtonContainer.tsx
+++ b/src/app/createAlbaform/applicant/components/ButtonContainer.tsx
@@ -2,7 +2,7 @@ import Image from 'next/image';
 import { ApplyFormLogicsProps } from '../../types';
 
 export default function ButtonContainer(props: ApplyFormLogicsProps) {
-  const { form, isPending } = props;
+  const { form, isPending, handleDraftSave } = props;
   const { formState } = form;
   const { isValid } = formState;
 
@@ -11,6 +11,7 @@ export default function ButtonContainer(props: ApplyFormLogicsProps) {
       <button
         type='button'
         className='flex-[1] h-14 px-6 border border-solid border-line-100 text-center text-gray-400 rounded-[8px]'
+        onClick={handleDraftSave}
       >
         임시 저장
       </button>

--- a/src/app/createAlbaform/applicant/components/ButtonContainer.tsx
+++ b/src/app/createAlbaform/applicant/components/ButtonContainer.tsx
@@ -1,0 +1,15 @@
+export default function ButtonContainer() {
+  return (
+    <div className='flex items-center gap-x-2'>
+      <button
+        type='button'
+        className='flex-[1] h-14 px-6 border border-solid border-line-100 text-center text-gray-400 rounded-[8px]'
+      >
+        임시 저장
+      </button>
+      <button className='flex-[1] h-14 px-6 text-center bg-gray-300 text-white rounded-[8px]'>
+        작성 완료
+      </button>
+    </div>
+  );
+}

--- a/src/app/createAlbaform/applicant/components/FileInputContainer.tsx
+++ b/src/app/createAlbaform/applicant/components/FileInputContainer.tsx
@@ -1,16 +1,23 @@
 import Image from 'next/image';
+import { ApplyFormLogicsProps } from '../../types';
 
-export default function FileInputContainer() {
+export default function FileInputContainer(props: ApplyFormLogicsProps) {
+  const { form } = props;
+  const { setValue, trigger, watch, register, formState } = form;
+  const { errors } = formState;
+
+  const resumeValue = watch('resume');
+
   return (
-    <>
+    <div className='mb-[50px]'>
       <p className='inline-block mb-4'>
         이력서 <span className='text-orange-400 ml-1'>*</span>
       </p>
       <label
         htmlFor='file-upload'
-        className='flex justify-between w-full h-14 mb-[50px] bg-gray-100 rounded-[8px] px-[14px] py-4 text-[18px] cursor-pointer text-gray-400'
+        className='flex justify-between w-full h-14 bg-gray-100 rounded-[8px] px-[14px] py-4 text-[18px] cursor-pointer text-gray-400'
       >
-        <p>파일 업로드하기</p>
+        <p>{resumeValue?.length > 0 ? resumeValue : '파일 업로드하기'}</p>
         <Image
           src='/images/createAlbaform/iconUpload.svg'
           alt='Upload'
@@ -20,11 +27,23 @@ export default function FileInputContainer() {
       </label>
       <input
         id='file-upload'
-        name='file'
         accept='.pdf'
+        {...register('resume')}
         type='file'
         className='hidden'
+        onChange={(e) => {
+          const file = e.currentTarget.files?.[0];
+          if (!file) return;
+
+          setValue('resume', file.name, {
+            shouldDirty: true,
+          });
+          trigger('resume');
+        }}
       />
-    </>
+      {errors.resume?.message && (
+        <p className='text-left mt-[10px] text-red'>{errors.resume?.message}</p>
+      )}
+    </div>
   );
 }

--- a/src/app/createAlbaform/applicant/components/FileInputContainer.tsx
+++ b/src/app/createAlbaform/applicant/components/FileInputContainer.tsx
@@ -1,7 +1,10 @@
 import Image from 'next/image';
 import { ApplyFormLogicsProps } from '../../types';
+import { useState } from 'react';
 
 export default function FileInputContainer(props: ApplyFormLogicsProps) {
+  const [resumeName, setResumeName] = useState('');
+
   const { form } = props;
   const { setValue, trigger, watch, register, formState } = form;
   const { errors } = formState;
@@ -17,7 +20,7 @@ export default function FileInputContainer(props: ApplyFormLogicsProps) {
         htmlFor='file-upload'
         className='flex justify-between w-full h-14 bg-gray-100 rounded-[8px] px-[14px] py-4 text-[18px] cursor-pointer text-gray-400'
       >
-        <p>{resumeValue?.length > 0 ? resumeValue : '파일 업로드하기'}</p>
+        <p>{resumeName === '' ? '파일 업로드하기' : resumeName}</p>
         <Image
           src='/images/createAlbaform/iconUpload.svg'
           alt='Upload'
@@ -27,7 +30,7 @@ export default function FileInputContainer(props: ApplyFormLogicsProps) {
       </label>
       <input
         id='file-upload'
-        accept='.pdf'
+        accept='.pdf, .doc, .docx'
         {...register('resume')}
         type='file'
         className='hidden'
@@ -35,7 +38,8 @@ export default function FileInputContainer(props: ApplyFormLogicsProps) {
           const file = e.currentTarget.files?.[0];
           if (!file) return;
 
-          setValue('resume', file.name, {
+          setResumeName(file.name);
+          setValue('resume', file, {
             shouldDirty: true,
           });
           trigger('resume');

--- a/src/app/createAlbaform/applicant/components/FileInputContainer.tsx
+++ b/src/app/createAlbaform/applicant/components/FileInputContainer.tsx
@@ -6,10 +6,8 @@ export default function FileInputContainer(props: ApplyFormLogicsProps) {
   const [resumeName, setResumeName] = useState('');
 
   const { form } = props;
-  const { setValue, trigger, watch, register, formState } = form;
+  const { setValue, trigger, register, formState } = form;
   const { errors } = formState;
-
-  const resumeValue = watch('resume');
 
   return (
     <div className='mb-[50px]'>

--- a/src/app/createAlbaform/applicant/components/FileInputContainer.tsx
+++ b/src/app/createAlbaform/applicant/components/FileInputContainer.tsx
@@ -29,7 +29,7 @@ export default function FileInputContainer(props: ApplyFormLogicsProps) {
       <input
         id='file-upload'
         accept='.pdf, .doc, .docx'
-        {...register('resume')}
+        {...register('resume', { required: true })}
         type='file'
         className='hidden'
         onChange={(e) => {
@@ -39,6 +39,7 @@ export default function FileInputContainer(props: ApplyFormLogicsProps) {
           setResumeName(file.name);
           setValue('resume', file, {
             shouldDirty: true,
+            shouldValidate: true,
           });
           trigger('resume');
         }}

--- a/src/app/createAlbaform/applicant/components/FileInputContainer.tsx
+++ b/src/app/createAlbaform/applicant/components/FileInputContainer.tsx
@@ -1,0 +1,30 @@
+import Image from 'next/image';
+
+export default function FileInputContainer() {
+  return (
+    <>
+      <p className='inline-block mb-4'>
+        이력서 <span className='text-orange-400 ml-1'>*</span>
+      </p>
+      <label
+        htmlFor='file-upload'
+        className='flex justify-between w-full h-14 mb-[50px] bg-gray-100 rounded-[8px] px-[14px] py-4 text-[18px] cursor-pointer text-gray-400'
+      >
+        <p>파일 업로드하기</p>
+        <Image
+          src='/images/createAlbaform/iconUpload.svg'
+          alt='Upload'
+          width={36}
+          height={36}
+        />
+      </label>
+      <input
+        id='file-upload'
+        name='file'
+        accept='.pdf'
+        type='file'
+        className='hidden'
+      />
+    </>
+  );
+}

--- a/src/app/createAlbaform/applicant/components/FormContainer.tsx
+++ b/src/app/createAlbaform/applicant/components/FormContainer.tsx
@@ -6,16 +6,43 @@ import TextInputcontainer from './TextInputContainer';
 import ButtonContainer from './ButtonContainer';
 import { INPUT_ITEMS } from '../constants/inputItems';
 import { useApplyForm } from '../hooks/useApplyForm';
+import { useGetMyInfo } from '@/hooks/query/useGetUser';
+import { useDraft } from '../hooks/useDraft';
+import RestoreModal from './RestoreModal';
+import { useDraftController } from '../hooks/useDraftController';
 
 export default function FormContainer({ formId }: { formId: number }) {
   const router = useRouter();
 
-  const formLogic = useApplyForm(formId);
+  const { data: user } = useGetMyInfo();
+  const { id: userId } = user ?? {};
+
+  const formLogic = useApplyForm(formId, userId);
   const { form, onSubmit, isPending } = formLogic;
   const { handleSubmit } = form;
 
+  const {
+    showRestoreModal,
+    isValue,
+    setIsValue,
+    onConfirm,
+    onCancel,
+    handleDraftChange,
+    handleDraftSave,
+  } = useDraftController(form, userId, formId);
+
+  useDraft({
+    userId,
+    formId,
+    data: isValue,
+    setData: setIsValue,
+  });
+
   return (
     <>
+      {showRestoreModal && (
+        <RestoreModal onConfirm={onConfirm} onCancel={onCancel} />
+      )}
       <div className='flex items-center justify-between my-10'>
         <p className='text-[26px] font-semibold'>알바폼 지원하기</p>
         <button
@@ -42,13 +69,17 @@ export default function FormContainer({ formId }: { formId: number }) {
                   type={type}
                   placeholder={placeholder}
                   formLogic={formLogic}
+                  handleDraftChange={handleDraftChange}
                 />
               </React.Fragment>
             );
           })}
           <FileInputContainer {...formLogic} />
-          <TextareaContainer {...formLogic} />
-          <ButtonContainer {...formLogic} />
+          <TextareaContainer
+            {...formLogic}
+            handleDraftChange={handleDraftChange}
+          />
+          <ButtonContainer {...formLogic} handleDraftSave={handleDraftSave} />
         </fieldset>
       </form>
     </>

--- a/src/app/createAlbaform/applicant/components/FormContainer.tsx
+++ b/src/app/createAlbaform/applicant/components/FormContainer.tsx
@@ -36,7 +36,7 @@ export default function FormContainer() {
           onClick={() => {
             router.back();
           }}
-          className='h-12 rounded-[8px] bg-gray-300 text-white text-[18px] px-6'
+          className='h-12 rounded-[8px] bg-gray-300 text-white px-6'
         >
           작성 취소
         </button>

--- a/src/app/createAlbaform/applicant/components/FormContainer.tsx
+++ b/src/app/createAlbaform/applicant/components/FormContainer.tsx
@@ -1,0 +1,62 @@
+import { useRouter } from 'next/navigation';
+import FileInputContainer from './FileInputContainer';
+import TextareaContainer from './TextareaContainer';
+import TextInputcontainer from './TextInputContainer';
+import ButtonContainer from './ButtonContainer';
+
+export default function FormContainer() {
+  const INPUT_ITEMS = [
+    {
+      label: '이름',
+      name: 'name',
+      type: 'text',
+      placeholder: '이름을 입력해주세요',
+    },
+    {
+      label: '연락처',
+      name: 'phoneNumber',
+      type: 'number',
+      placeholder: '숫자만 입력해주세요',
+    },
+    {
+      label: '경력(개월 수)',
+      name: 'experienceMonths',
+      type: 'number',
+      placeholder: '숫자만 입력해주세요',
+    },
+  ];
+  const router = useRouter();
+
+  return (
+    <>
+      <div className='flex items-center justify-between my-10'>
+        <p className='text-[26px] font-semibold'>알바폼 지원하기</p>
+        <button
+          type='button'
+          onClick={() => {
+            router.back();
+          }}
+          className='h-12 rounded-[8px] bg-gray-300 text-white text-[18px] px-6'
+        >
+          작성 취소
+        </button>
+      </div>
+      <form>
+        {INPUT_ITEMS.map((item, i) => {
+          return (
+            <TextInputcontainer
+              key={i}
+              label={item.label}
+              name={item.name}
+              type={item.type}
+              placeholder={item.placeholder}
+            />
+          );
+        })}
+        <FileInputContainer />
+        <TextareaContainer />
+        <ButtonContainer />
+      </form>
+    </>
+  );
+}

--- a/src/app/createAlbaform/applicant/components/FormContainer.tsx
+++ b/src/app/createAlbaform/applicant/components/FormContainer.tsx
@@ -1,31 +1,18 @@
+import React from 'react';
 import { useRouter } from 'next/navigation';
 import FileInputContainer from './FileInputContainer';
 import TextareaContainer from './TextareaContainer';
 import TextInputcontainer from './TextInputContainer';
 import ButtonContainer from './ButtonContainer';
+import { INPUT_ITEMS } from '../constants/inputItems';
+import { useApplyForm } from '../hooks/useApplyForm';
 
-export default function FormContainer() {
-  const INPUT_ITEMS = [
-    {
-      label: '이름',
-      name: 'name',
-      type: 'text',
-      placeholder: '이름을 입력해주세요',
-    },
-    {
-      label: '연락처',
-      name: 'phoneNumber',
-      type: 'number',
-      placeholder: '숫자만 입력해주세요',
-    },
-    {
-      label: '경력(개월 수)',
-      name: 'experienceMonths',
-      type: 'number',
-      placeholder: '숫자만 입력해주세요',
-    },
-  ];
+export default function FormContainer({ formId }: { formId: number }) {
   const router = useRouter();
+
+  const formLogic = useApplyForm(formId);
+  const { form, onSubmit, isPending } = formLogic;
+  const { handleSubmit } = form;
 
   return (
     <>
@@ -41,21 +28,28 @@ export default function FormContainer() {
           작성 취소
         </button>
       </div>
-      <form>
-        {INPUT_ITEMS.map((item, i) => {
-          return (
-            <TextInputcontainer
-              key={i}
-              label={item.label}
-              name={item.name}
-              type={item.type}
-              placeholder={item.placeholder}
-            />
-          );
-        })}
-        <FileInputContainer />
-        <TextareaContainer />
-        <ButtonContainer />
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <fieldset
+          disabled={isPending}
+          className={`${isPending ? 'pointer-events-none' : ''}`}
+        >
+          {INPUT_ITEMS.map(({ label, name, type, placeholder }, i) => {
+            return (
+              <React.Fragment key={i}>
+                <TextInputcontainer
+                  label={label}
+                  name={name}
+                  type={type}
+                  placeholder={placeholder}
+                  formLogic={formLogic}
+                />
+              </React.Fragment>
+            );
+          })}
+          <FileInputContainer {...formLogic} />
+          <TextareaContainer {...formLogic} />
+          <ButtonContainer {...formLogic} />
+        </fieldset>
       </form>
     </>
   );

--- a/src/app/createAlbaform/applicant/components/RestoreModal.tsx
+++ b/src/app/createAlbaform/applicant/components/RestoreModal.tsx
@@ -1,0 +1,38 @@
+import { RestoreModalProps } from '../../types';
+
+export default function RestoreModal({
+  onConfirm,
+  onCancel,
+}: RestoreModalProps) {
+  return (
+    <div
+      className='fixed inset-0 flex items-center justify-center z-[1000]'
+      style={{ background: 'rgba(0,0,0,.5)' }}
+    >
+      <div className='bg-white p-6 rounded-xl shadow-lg text-center max-w-[350px] w-full mx-6'>
+        <p className='mb-6 text-[18px] font-medium'>
+          임시 저장된 내용이 있습니다.
+          <br />
+          복구하시겠어요?
+          <span className='block pt-2 pb-3 text-[14px] text-gray-400 font-light'>
+            복구하지 않으면 임시 저장된 내용이 삭제 됩니다.
+          </span>
+        </p>
+        <div className='flex justify-center gap-4'>
+          <button
+            className='px-8 py-2 rounded bg-orange-400 text-white min-w-[110px] box-border'
+            onClick={onConfirm}
+          >
+            복구
+          </button>
+          <button
+            className='px-8 py-2 rounded border border-solid border-gray-200 text-gray-400 min-w-[110px] box-border'
+            onClick={onCancel}
+          >
+            아니요
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/createAlbaform/applicant/components/TextInputContainer.tsx
+++ b/src/app/createAlbaform/applicant/components/TextInputContainer.tsx
@@ -1,0 +1,23 @@
+import { TextInputProps } from '../../types';
+
+export default function TextInputcontainer({
+  label,
+  name,
+  type,
+  placeholder,
+}: TextInputProps) {
+  return (
+    <>
+      <label htmlFor={name} className='inline-block mb-4'>
+        {label} <span className='text-orange-400 ml-1'>*</span>
+      </label>
+      <input
+        id={name}
+        name={name}
+        placeholder={placeholder}
+        type={type}
+        className='w-full h-14 mb-[50px] bg-gray-100 rounded-[8px] px-[14px] py-4 text-[18px]'
+      />
+    </>
+  );
+}

--- a/src/app/createAlbaform/applicant/components/TextInputContainer.tsx
+++ b/src/app/createAlbaform/applicant/components/TextInputContainer.tsx
@@ -1,23 +1,47 @@
 import { TextInputProps } from '../../types';
+import { formattedPhoneNumber } from '@/utils/formattedPhoneNumber';
 
 export default function TextInputcontainer({
   label,
   name,
   type,
   placeholder,
+  formLogic,
 }: TextInputProps) {
+  const { form } = formLogic;
+  const { register, formState, setValue } = form;
+  const { errors } = formState;
+
   return (
-    <>
+    <div className='mb-[50px]'>
       <label htmlFor={name} className='inline-block mb-4'>
         {label} <span className='text-orange-400 ml-1'>*</span>
       </label>
       <input
         id={name}
-        name={name}
+        inputMode={name === 'phoneNumber' ? 'numeric' : 'none'}
+        {...register(name)}
         placeholder={placeholder}
         type={type}
-        className='w-full h-14 mb-[50px] bg-gray-100 rounded-[8px] px-[14px] py-4 text-[18px]'
+        onWheel={(e) => name === 'experienceMonths' && e.currentTarget.blur()}
+        onChange={(e) => {
+          const onlyNums = e.target.value.replace(/[^0-9]/g, '');
+          const formatted = formattedPhoneNumber(onlyNums);
+          name === 'phoneNumber'
+            ? setValue('phoneNumber', formatted, {
+                shouldValidate: true,
+              })
+            : name === 'name' || name === 'experienceMonths'
+            ? setValue(name, e.target.value, {
+                shouldValidate: true,
+              })
+            : '';
+        }}
+        className='w-full h-14 bg-gray-100 rounded-[8px] px-[14px] py-4 text-[18px]'
       />
-    </>
+      {errors[name]?.message && (
+        <p className='text-left mt-[10px] text-red'>{errors[name]?.message}</p>
+      )}
+    </div>
   );
 }

--- a/src/app/createAlbaform/applicant/components/TextInputContainer.tsx
+++ b/src/app/createAlbaform/applicant/components/TextInputContainer.tsx
@@ -7,6 +7,7 @@ export default function TextInputcontainer({
   type,
   placeholder,
   formLogic,
+  handleDraftChange,
 }: TextInputProps) {
   const { form } = formLogic;
   const { register, formState, setValue } = form;
@@ -25,6 +26,8 @@ export default function TextInputcontainer({
         type={type}
         onWheel={(e) => name === 'experienceMonths' && e.currentTarget.blur()}
         onChange={(e) => {
+          handleDraftChange?.(e);
+
           const onlyNums = e.target.value.replace(/[^0-9]/g, '');
           const formatted = formattedPhoneNumber(onlyNums);
           name === 'phoneNumber'

--- a/src/app/createAlbaform/applicant/components/TextareaContainer.tsx
+++ b/src/app/createAlbaform/applicant/components/TextareaContainer.tsx
@@ -1,15 +1,27 @@
-export default function TextareaContainer() {
+import { ApplyFormLogicsProps } from '../../types';
+
+export default function TextareaContainer(props: ApplyFormLogicsProps) {
+  const { form } = props;
+  const { register, formState } = form;
+  const { errors } = formState;
+
   return (
-    <>
+    <div className='mb-[50px]'>
       <label htmlFor='introduction' className='inline-block mb-4'>
         자기소개 <span className='text-orange-400 ml-1'>*</span>
       </label>
       <textarea
         id='introduction'
+        {...register('introduction')}
         name='introduction'
         placeholder='최대 200자까지 입력 가능합니다.'
-        className='w-full h-[calc(100vw_*_(160/640))] max-h-[260px] min-h-[160px] mb-[50px] bg-gray-100 rounded-[8px] px-[14px] py-4 text-[18px]'
+        className='w-full h-[calc(100vw_*_(160/640))] max-h-[260px] min-h-[160px] bg-gray-100 rounded-[8px] px-[14px] py-4 text-[18px]'
       />
-    </>
+      {errors.introduction?.message && (
+        <p className='text-left mt-[10px] text-red'>
+          {errors.introduction?.message}
+        </p>
+      )}
+    </div>
   );
 }

--- a/src/app/createAlbaform/applicant/components/TextareaContainer.tsx
+++ b/src/app/createAlbaform/applicant/components/TextareaContainer.tsx
@@ -1,0 +1,15 @@
+export default function TextareaContainer() {
+  return (
+    <>
+      <label htmlFor='introduction' className='inline-block mb-4'>
+        자기소개 <span className='text-orange-400 ml-1'>*</span>
+      </label>
+      <textarea
+        id='introduction'
+        name='introduction'
+        placeholder='최대 200자까지 입력 가능합니다.'
+        className='w-full h-[calc(100vw_*_(160/640))] max-h-[260px] min-h-[160px] mb-[50px] bg-gray-100 rounded-[8px] px-[14px] py-4 text-[18px]'
+      />
+    </>
+  );
+}

--- a/src/app/createAlbaform/applicant/components/TextareaContainer.tsx
+++ b/src/app/createAlbaform/applicant/components/TextareaContainer.tsx
@@ -1,8 +1,9 @@
 import { ApplyFormLogicsProps } from '../../types';
 
 export default function TextareaContainer(props: ApplyFormLogicsProps) {
-  const { form } = props;
+  const { form, handleDraftChange } = props;
   const { register, formState } = form;
+  const { onChange, ...rest } = register('introduction');
   const { errors } = formState;
 
   return (
@@ -12,8 +13,12 @@ export default function TextareaContainer(props: ApplyFormLogicsProps) {
       </label>
       <textarea
         id='introduction'
-        {...register('introduction')}
+        {...rest}
         name='introduction'
+        onChange={(e) => {
+          onChange(e);
+          handleDraftChange?.(e);
+        }}
         placeholder='최대 200자까지 입력 가능합니다.'
         className='w-full h-[calc(100vw_*_(160/640))] max-h-[260px] min-h-[160px] bg-gray-100 rounded-[8px] px-[14px] py-4 text-[18px]'
       />

--- a/src/app/createAlbaform/applicant/constants/inputItems.ts
+++ b/src/app/createAlbaform/applicant/constants/inputItems.ts
@@ -1,0 +1,29 @@
+import { AlbaformApplyInput } from '@/schemas/albaformApplySchema';
+
+type InputItem = {
+  label: string;
+  name: keyof AlbaformApplyInput;
+  type: string;
+  placeholder: string;
+};
+
+export const INPUT_ITEMS: InputItem[] = [
+  {
+    label: '이름',
+    name: 'name',
+    type: 'text',
+    placeholder: '이름을 입력해주세요',
+  },
+  {
+    label: '연락처',
+    name: 'phoneNumber',
+    type: 'tel',
+    placeholder: '숫자만 입력해주세요',
+  },
+  {
+    label: '경력(개월 수)',
+    name: 'experienceMonths',
+    type: 'number',
+    placeholder: '숫자만 입력해주세요',
+  },
+];

--- a/src/app/createAlbaform/applicant/hooks/useApplyForm.ts
+++ b/src/app/createAlbaform/applicant/hooks/useApplyForm.ts
@@ -9,10 +9,13 @@ import { useRouter } from 'next/navigation';
 import { useForm } from 'react-hook-form';
 import { AlbaformApplyPayload } from '../../types';
 import { useQueryClient } from '@tanstack/react-query';
+import { useToastStore } from '@/stores/useToastStore';
 
 export const useApplyForm = (formId: number) => {
   const router = useRouter();
   const queryClient = useQueryClient();
+
+  const { showToast } = useToastStore();
 
   const { mutateAsync: postUploadResume, isPending: postFilePending } =
     useUploadResume();
@@ -62,6 +65,7 @@ export const useApplyForm = (formId: number) => {
         onSuccess: () => {
           router.push('/myAlbaform/applicant');
           queryClient.invalidateQueries({ queryKey: ['myApplications'] });
+          showToast('공고 지원이 완료 되었습니다 !');
         },
       },
     );

--- a/src/app/createAlbaform/applicant/hooks/useApplyForm.ts
+++ b/src/app/createAlbaform/applicant/hooks/useApplyForm.ts
@@ -1,0 +1,39 @@
+import { useApplications } from '@/hooks/mutation/useApplications';
+import {
+  AlbaformApplyInput,
+  albaformApplySchema,
+} from '@/schemas/albaformApplySchema';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useRouter } from 'next/navigation';
+import { useForm } from 'react-hook-form';
+
+export const useApplyForm = (formId: number) => {
+  const router = useRouter();
+
+  const { mutate: postApplyForm, isPending } = useApplications();
+
+  const form = useForm<AlbaformApplyInput>({
+    resolver: zodResolver(albaformApplySchema),
+    mode: 'onChange',
+  });
+
+  const onSubmit = async (formData: AlbaformApplyInput) => {
+    let password = '';
+
+    const payload = {
+      ...formData,
+      experienceMonths: Number(formData.experienceMonths),
+      password,
+    };
+    postApplyForm(
+      { formId, payload },
+      {
+        onSuccess: () => {
+          router.push('/myAlbaform/applicant');
+        },
+      },
+    );
+  };
+
+  return { form, onSubmit, isPending };
+};

--- a/src/app/createAlbaform/applicant/hooks/useApplyForm.ts
+++ b/src/app/createAlbaform/applicant/hooks/useApplyForm.ts
@@ -10,8 +10,9 @@ import { useForm } from 'react-hook-form';
 import { AlbaformApplyPayload } from '../../types';
 import { useQueryClient } from '@tanstack/react-query';
 import { useToastStore } from '@/stores/useToastStore';
+import { getStorageKey } from '../utils/getStorageKey';
 
-export const useApplyForm = (formId: number) => {
+export const useApplyForm = (formId: number, userId: number) => {
   const router = useRouter();
   const queryClient = useQueryClient();
 
@@ -66,6 +67,9 @@ export const useApplyForm = (formId: number) => {
           router.push('/myAlbaform/applicant');
           queryClient.invalidateQueries({ queryKey: ['myApplications'] });
           showToast('공고 지원이 완료 되었습니다 !');
+
+          const key = getStorageKey(userId, formId);
+          localStorage.removeItem(key);
         },
       },
     );

--- a/src/app/createAlbaform/applicant/hooks/useDraft.ts
+++ b/src/app/createAlbaform/applicant/hooks/useDraft.ts
@@ -1,0 +1,38 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { loadFromLocalStorage } from '../utils/loadFromLocalStorage';
+import { saveToLocalStorage } from '../utils/saveToLocalStorage';
+import { AlbaformWithResume, DraftAlbaform } from '../../types';
+
+export const useDraft = ({
+  userId,
+  formId,
+  data,
+  setData,
+}: {
+  userId: number;
+  formId: number;
+  data: DraftAlbaform;
+  setData: (data: AlbaformWithResume) => void;
+}) => {
+  const initialized = useRef(false);
+
+  useEffect(() => {
+    if (!userId || !formId || initialized.current) return;
+    const saved = loadFromLocalStorage(userId, formId) as DraftAlbaform | null;
+    if (saved) {
+      setData({ ...saved, resume: null });
+    }
+    initialized.current = true;
+  }, [userId, formId, setData]);
+
+  useEffect(() => {
+    if (!userId || !formId) return;
+    const timer = setTimeout(() => {
+      saveToLocalStorage(userId, formId, data);
+    }, 1000);
+
+    return () => clearTimeout(timer);
+  }, [data, userId, formId]);
+};

--- a/src/app/createAlbaform/applicant/hooks/useDraftController.ts
+++ b/src/app/createAlbaform/applicant/hooks/useDraftController.ts
@@ -1,0 +1,97 @@
+import { useEffect, useRef, useState } from 'react';
+import { DraftAlbaform } from '../../types';
+import { restoreDraftToForm } from '../utils/restoreDraftToForm';
+import { UseFormReturn } from 'react-hook-form';
+import { AlbaformApplyInput } from '@/schemas/albaformApplySchema';
+import { useToastStore } from '@/stores/useToastStore';
+import { getStorageKey } from '../utils/getStorageKey';
+
+export const useDraftController = (
+  form: UseFormReturn<AlbaformApplyInput>,
+  userId: number,
+  formId: number,
+) => {
+  const { showToast } = useToastStore();
+
+  const [showRestoreModal, setShowRestoreModal] = useState(false);
+  const restoreDataRef = useRef<DraftAlbaform | null>(null);
+  const [isValue, setIsValue] = useState<{
+    name: string;
+    phoneNumber: string;
+    experienceMonths: string;
+    resume: File | null;
+    resumeName?: string;
+    introduction: string;
+  }>({
+    name: '',
+    phoneNumber: '',
+    experienceMonths: '',
+    resume: null,
+    resumeName: '',
+    introduction: '',
+  });
+
+  const handleDraftChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => {
+    setIsValue((prev) => ({
+      ...prev,
+      [e.target.name]: e.target.value,
+    }));
+  };
+
+  const handleDraftSave = () => {
+    const key = `application_draft_${userId}_${formId}`;
+    const { resume, ...saveableForm } = isValue;
+    localStorage.setItem(key, JSON.stringify(saveableForm));
+    showToast('임시 저장이 완료 되었습니다 !');
+  };
+
+  useEffect(() => {
+    if (!userId) return;
+
+    const key = `application_draft_${userId}_${formId}`;
+    const saved = localStorage.getItem(key);
+
+    if (saved) {
+      try {
+        const parsed = JSON.parse(saved);
+        restoreDataRef.current = parsed;
+        setShowRestoreModal(true);
+      } catch (e) {
+        console.error('복구 데이터 파싱 오류:', e);
+      }
+    }
+  }, [userId]);
+
+  const onConfirm = () => {
+    if (!restoreDataRef.current) return;
+
+    restoreDraftToForm({
+      userId,
+      formId,
+      setValue: form.setValue,
+      setIsValue,
+    });
+
+    setShowRestoreModal(false);
+    showToast('임시 저장된 내용을 복원했습니다 !');
+  };
+
+  const onCancel = () => {
+    setShowRestoreModal(false);
+
+    const key = getStorageKey(userId, formId);
+    localStorage.removeItem(key);
+  };
+
+  return {
+    showRestoreModal,
+    isValue,
+    setIsValue,
+    onConfirm,
+    onCancel,
+    handleDraftChange,
+    handleDraftSave,
+  };
+};

--- a/src/app/createAlbaform/applicant/page.tsx
+++ b/src/app/createAlbaform/applicant/page.tsx
@@ -2,11 +2,16 @@
 
 import FormContainer from './components/FormContainer';
 import { ApplyFormResponsive } from '../styles';
+import { useSearchParams } from 'next/navigation';
 
 export default function ApplyForm() {
+  const searchParams = useSearchParams();
+  const searchParam = searchParams.get('formId');
+  const formId = Number(searchParam);
+
   return (
     <ApplyFormResponsive>
-      <FormContainer />
+      <FormContainer formId={formId} />
     </ApplyFormResponsive>
   );
 }

--- a/src/app/createAlbaform/applicant/page.tsx
+++ b/src/app/createAlbaform/applicant/page.tsx
@@ -1,3 +1,12 @@
+'use client';
+
+import FormContainer from './components/FormContainer';
+import { ApplyFormResponsive } from '../styles';
+
 export default function ApplyForm() {
-  return <></>;
+  return (
+    <ApplyFormResponsive>
+      <FormContainer />
+    </ApplyFormResponsive>
+  );
 }

--- a/src/app/createAlbaform/applicant/utils/getStorageKey.ts
+++ b/src/app/createAlbaform/applicant/utils/getStorageKey.ts
@@ -1,0 +1,3 @@
+export const getStorageKey = (userId: number, formId: number) => {
+  return `application_draft_${userId}_${formId}`;
+};

--- a/src/app/createAlbaform/applicant/utils/loadFromLocalStorage.ts
+++ b/src/app/createAlbaform/applicant/utils/loadFromLocalStorage.ts
@@ -1,0 +1,10 @@
+import { getStorageKey } from './getStorageKey';
+
+export const loadFromLocalStorage = (
+  userId: number,
+  formId: number,
+): any | null => {
+  const key = getStorageKey(userId, formId);
+  const raw = localStorage.getItem(key);
+  return raw ? JSON.parse(raw) : null;
+};

--- a/src/app/createAlbaform/applicant/utils/restoreDraftToForm.ts
+++ b/src/app/createAlbaform/applicant/utils/restoreDraftToForm.ts
@@ -1,0 +1,50 @@
+import { AlbaformWithResume, DraftAlbaform } from '../../types';
+import { UseFormReturn } from 'react-hook-form';
+
+export function restoreDraftToForm({
+  userId,
+  formId,
+  setValue,
+  setIsValue,
+  setResumeName,
+}: {
+  userId: number;
+  formId: number;
+  setValue: UseFormReturn<any>['setValue'];
+  setIsValue: React.Dispatch<React.SetStateAction<AlbaformWithResume>>;
+  setResumeName?: (name: string) => void;
+}) {
+  const key = `application_draft_${userId}_${formId}`;
+  const saved = localStorage.getItem(key);
+  if (!saved) return;
+
+  try {
+    const parsed = JSON.parse(saved) as DraftAlbaform;
+    const { resumeName, ...rest } = parsed;
+
+    // 1. RHF 값 복원
+    (Object.entries(rest) as [keyof DraftAlbaform, any][]).forEach(
+      ([key, value]) => {
+        setValue(key, value, {
+          shouldDirty: true,
+          shouldValidate: true,
+        });
+      },
+    );
+
+    // 2. isValue 상태 복원
+    setIsValue((prev) => ({
+      ...prev,
+      ...rest,
+      resume: null, // resume은 복원 불가
+      resumeName: resumeName ?? '',
+    }));
+
+    // 3. resumeName 따로 표시
+    if (resumeName && setResumeName) {
+      setResumeName(resumeName);
+    }
+  } catch (err) {
+    console.error('복구 실패', err);
+  }
+}

--- a/src/app/createAlbaform/applicant/utils/saveToLocalStorage.ts
+++ b/src/app/createAlbaform/applicant/utils/saveToLocalStorage.ts
@@ -1,0 +1,10 @@
+import { DraftAlbaform } from '../../types';
+
+export const saveToLocalStorage = (
+  userId: number,
+  formId: number,
+  data: DraftAlbaform,
+) => {
+  const key = `albaform_draft_${userId}_${formId}`;
+  localStorage.setItem(key, JSON.stringify(data));
+};

--- a/src/app/createAlbaform/styles.ts
+++ b/src/app/createAlbaform/styles.ts
@@ -1,0 +1,23 @@
+import { media } from '@/styles/media';
+import styled from 'styled-components';
+
+export const ApplyFormResponsive = styled.div`
+  position: relative;
+  min-height: 100%;
+  padding: 88px 0 calc(env(safe-area-inset-bottom) + 62px);
+  width: calc(100vw * (640 / 1920));
+  max-width: 1000px;
+  min-width: 640px;
+  margin: 0 auto;
+
+  @media ${media.tablet} {
+    padding: 60px 24px calc(env(safe-area-inset-bottom) + 62px);
+    width: 100%;
+    min-width: auto;
+    margin: 0;
+  }
+
+  @media ${media.mobile} {
+    padding: 54px 24px calc(env(safe-area-inset-bottom) + 62px);
+  }
+`;

--- a/src/app/createAlbaform/types.ts
+++ b/src/app/createAlbaform/types.ts
@@ -1,6 +1,23 @@
+import { AlbaformApplyInput } from '@/schemas/albaformApplySchema';
+import { UseFormReturn } from 'react-hook-form';
+
 export interface TextInputProps {
   label: string;
-  name: string;
+  name: keyof AlbaformApplyInput;
   type: string;
   placeholder: string;
+  formLogic: ApplyFormLogicsProps;
 }
+
+export interface ApplyFormLogicsProps {
+  form: UseFormReturn<AlbaformApplyInput>;
+  onSubmit: (formData: AlbaformApplyInput) => void;
+  isPending: boolean;
+}
+
+export type AlbaformApplyPayload = Omit<
+  AlbaformApplyInput,
+  'experienceMonths'
+> & {
+  experienceMonths: number;
+};

--- a/src/app/createAlbaform/types.ts
+++ b/src/app/createAlbaform/types.ts
@@ -17,7 +17,10 @@ export interface ApplyFormLogicsProps {
 
 export type AlbaformApplyPayload = Omit<
   AlbaformApplyInput,
-  'experienceMonths'
+  'experienceMonths' | 'resume'
 > & {
   experienceMonths: number;
+  resumeId: number;
+  resumeName: string;
+  password: string;
 };

--- a/src/app/createAlbaform/types.ts
+++ b/src/app/createAlbaform/types.ts
@@ -1,0 +1,6 @@
+export interface TextInputProps {
+  label: string;
+  name: string;
+  type: string;
+  placeholder: string;
+}

--- a/src/app/createAlbaform/types.ts
+++ b/src/app/createAlbaform/types.ts
@@ -1,4 +1,5 @@
 import { AlbaformApplyInput } from '@/schemas/albaformApplySchema';
+import React from 'react';
 import { UseFormReturn } from 'react-hook-form';
 
 export interface TextInputProps {
@@ -7,12 +8,19 @@ export interface TextInputProps {
   type: string;
   placeholder: string;
   formLogic: ApplyFormLogicsProps;
+  handleDraftChange: (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => void;
 }
 
 export interface ApplyFormLogicsProps {
   form: UseFormReturn<AlbaformApplyInput>;
   onSubmit: (formData: AlbaformApplyInput) => void;
   isPending: boolean;
+  handleDraftChange?: (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => void;
+  handleDraftSave?: () => void;
 }
 
 export type AlbaformApplyPayload = Omit<
@@ -24,3 +32,14 @@ export type AlbaformApplyPayload = Omit<
   resumeName: string;
   password: string;
 };
+
+export type DraftAlbaform = Omit<AlbaformApplyInput, 'resume'> & {
+  resumeName?: string;
+};
+
+export type AlbaformWithResume = DraftAlbaform & { resume: File | null };
+
+export interface RestoreModalProps {
+  onConfirm: () => void;
+  onCancel: () => void;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,8 @@ import DaumPostcodeScript from '@/components/common/DaumPostcodeScript';
 import KakaoMapScript from '@/components/common/KakaoMapScript';
 import Script from 'next/script';
 import Navbar from '@/components/navbar/Navbar';
+import Toast from '@/components/tooltip/Toast';
+import GlobalToast from '@/components/tooltip/GlobalToast';
 
 export const metadata: Metadata = {
   title: 'Albaform',
@@ -43,6 +45,7 @@ export default async function RootLayout({
               <ClientLayout>
                 <Navbar />
                 {children}
+                <GlobalToast />
               </ClientLayout>
             </GlobalStyleProvider>
           </StyledComponentsRegistry>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { ReactNode, Suspense } from 'react';
 import type { Metadata } from 'next';
 import GlobalStyleProvider from '@/context/GlobalStyleProvider';
 import StyledComponentsRegistry from '../lib/StyledRegistry';
@@ -35,16 +35,18 @@ export default async function RootLayout({
         />
       </head>
       <body>
-        <DaumPostcodeScript />
-        <KakaoMapScript />
-        <StyledComponentsRegistry>
-          <GlobalStyleProvider>
-            <ClientLayout>
-              <Navbar />
-              {children}
-            </ClientLayout>
-          </GlobalStyleProvider>
-        </StyledComponentsRegistry>
+        <Suspense fallback={<div />}>
+          <DaumPostcodeScript />
+          <KakaoMapScript />
+          <StyledComponentsRegistry>
+            <GlobalStyleProvider>
+              <ClientLayout>
+                <Navbar />
+                {children}
+              </ClientLayout>
+            </GlobalStyleProvider>
+          </StyledComponentsRegistry>
+        </Suspense>
       </body>
     </html>
   );

--- a/src/app/mypage/components/scrapMenu/MenuDropdown.tsx
+++ b/src/app/mypage/components/scrapMenu/MenuDropdown.tsx
@@ -45,7 +45,7 @@ export default function MenuDropdown({
           type='button'
           onClick={(e) => {
             e.stopPropagation();
-            router.push(`/createAlbaform/applicant/${postId}`);
+            router.push(`/createAlbaform/applicant?formId=${postId}`);
           }}
         >
           지원하기

--- a/src/components/floatingbutton/FloatingButton.tsx
+++ b/src/components/floatingbutton/FloatingButton.tsx
@@ -56,12 +56,12 @@ export default function FloatingButton({
             />
           </button>
         </div>
-      ) : $myAlbaform ? (
+      ) : (
         <div
           className='fixed rounded-[50%] bg-primary-orange300 w-[64px] h-[64px] content-center justify-items-center bottom-[calc(100px+theme(spacing.safe-bottom))] right-[120px] min-xlg:right-[calc((100vw-1480px)/2)] max-md:right-[24px] cursor-pointer'
           onClick={() =>
             router.push(
-              `${$myAlbaform ? 'createAlbaform/owner' : 'albatalk/new'}`,
+              `${$myAlbaform ? '/createAlbaform/owner' : '/albatalk/new'}`,
             )
           }
         >
@@ -75,8 +75,6 @@ export default function FloatingButton({
             className={`relative ${!$myAlbaform && 'top-[-2px] left-[-1px]'}`}
           />
         </div>
-      ) : (
-        ''
       )}
     </>
   );

--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -14,6 +14,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useDeleteComments } from '@/hooks/mutation/useDeleteComments';
 import { useCancelScrapForms } from '@/hooks/mutation/useCancelScrapForms';
 import { useDeleteForm } from '@/hooks/mutation/useDeleteForm';
+import { useToastStore } from '@/stores/useToastStore';
 
 function Modal({
   showModal,
@@ -33,6 +34,8 @@ function Modal({
 
   const router = useRouter();
   const pathname = usePathname();
+
+  const { showToast } = useToastStore();
 
   const isAlbatalkDetail = /^\/albatalk\/[^/]+$/.test(pathname);
   const isAlbaformDetail = /^\/albaform\/[^/]+$/.test(pathname);
@@ -68,6 +71,7 @@ function Modal({
               },
             });
             if (isAlbatalkDetail) {
+              showToast('게시글이 삭제되었습니다 !');
               router.push('/albatalk');
             }
             onSuccess?.();

--- a/src/components/tooltip/GlobalToast.tsx
+++ b/src/components/tooltip/GlobalToast.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import React, { useEffect } from 'react';
+import Image from 'next/image';
+import styled from 'styled-components';
+import { useToastStore } from '@/stores/useToastStore';
+
+const Wrapper = styled(({ isVisible, ...rest }) => <div {...rest} />)<{
+  isVisible: boolean;
+}>`
+  position: fixed;
+  top: 24px;
+  left: 50%;
+  transform: translateX(-50%)
+    translateY(${({ isVisible }) => (isVisible ? '0' : '-10px')});
+  z-index: 9999;
+  opacity: ${({ isVisible }) => (isVisible ? 1 : 0)};
+  transition: opacity 0.3s ease, transform 0.3s ease;
+
+  display: flex;
+  align-items: center;
+  padding: 12px 32px;
+  background-color: var(--primary-blue300);
+  border-radius: 8px;
+  max-width: 640px;
+  width: 100%;
+  justify-content: center;
+
+  @media (max-width: 768px) {
+    max-width: 327px;
+    padding: 12px 16px;
+  }
+`;
+
+const Content = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+
+const Text = styled.p`
+  color: var(--white);
+  font-weight: 600;
+  font-size: 16px;
+  line-height: 24px;
+  margin: 0;
+`;
+
+const Icon = styled(Image)`
+  width: 20px;
+  height: 20px;
+`;
+
+export default function GlobalToast() {
+  const { message, show, hideToast } = useToastStore();
+
+  useEffect(() => {
+    if (show) {
+      const timer = setTimeout(() => {
+        hideToast();
+      }, 3000);
+      return () => clearTimeout(timer);
+    }
+  }, [show, hideToast]);
+
+  if (!show || !message) return null;
+
+  return (
+    <Wrapper isVisible={show} role='alert'>
+      <Content>
+        <Icon src='/images/toast.svg' alt='toast' width={20} height={20} />
+        <Text>{message}</Text>
+      </Content>
+    </Wrapper>
+  );
+}

--- a/src/components/tooltip/ToolTip.tsx
+++ b/src/components/tooltip/ToolTip.tsx
@@ -13,24 +13,21 @@
 import React from 'react';
 import Image from 'next/image';
 import styled from 'styled-components';
-import CloseButton from '../closebutton/CloseButton';
 
 interface TooltipProps {
   children: React.ReactNode;
-  onClose: () => void;
 }
 
 const Wrapper = styled.div`
   position: relative;
   display: flex;
-  //justify-content: space-between;
   align-items: center;
   gap: 12px;
   border-radius: 8px;
   background-color: var(--primary-blue300);
   max-width: 476px;
   width: 100%;
-  padding: 16px 24px;
+  padding: 12px 24px 12px 15px;
 
   &::before {
     content: '';
@@ -45,17 +42,9 @@ const Wrapper = styled.div`
   }
 
   @media (max-width: 768px) {
-    padding: 8px 12px;
+    padding: 8px 18px 8px 12px;
     max-width: 300px;
   }
-`;
-
-const Tail = styled.div`
-  width: 0;
-  height: 0;
-  border-left: 8px solid transparent;
-  border-right: 8px solid transparent;
-  border-bottom: 10px solid var(--primary-blue300);
 `;
 
 const ContentWrapper = styled.div`
@@ -65,15 +54,10 @@ const ContentWrapper = styled.div`
   flex-grow: 1;
 `;
 
-const StyledCloseButton = styled.div`
-  margin-left: auto;
-  flex-shrink: 0;
-`;
-
 const Text = styled.p`
   display: flex;
   align-items: center;
-  font-size: 20px;
+  font-size: 14px;
   line-height: 32px;
   font-weight: 600;
   color: var(--white);
@@ -96,7 +80,7 @@ const Icon = styled(Image)`
   }
 `;
 
-export default function Tooltip({ children, onClose }: TooltipProps) {
+export default function Tooltip({ children }: TooltipProps) {
   return (
     <>
       <Wrapper>
@@ -109,9 +93,6 @@ export default function Tooltip({ children, onClose }: TooltipProps) {
           />
           <Text>{children}</Text>
         </ContentWrapper>
-        <StyledCloseButton>
-          <CloseButton onClose={() => onClose()} />
-        </StyledCloseButton>
       </Wrapper>
     </>
   );

--- a/src/hooks/mutation/useApplications.ts
+++ b/src/hooks/mutation/useApplications.ts
@@ -1,2 +1,11 @@
 // 지원하기
+
+import { fetchApplications } from "@/lib/fetch/application";
+import { useMutation } from "@tanstack/react-query";
+
 // POST 'forms/:formId/applications'
+export const useApplications = () => {
+    return useMutation({
+        mutationFn:fetchApplications
+    })
+};

--- a/src/hooks/mutation/useUploadResume.ts
+++ b/src/hooks/mutation/useUploadResume.ts
@@ -1,2 +1,11 @@
 // 이력서 업로드
+
+import { fetchUploadResume } from "@/lib/fetch/file"
+import { useMutation } from "@tanstack/react-query"
+
 // POST '/resume/upload'
+export const useUploadResume = () => {
+    return useMutation({
+        mutationFn:fetchUploadResume
+    })
+}

--- a/src/lib/fetch/application.ts
+++ b/src/lib/fetch/application.ts
@@ -10,9 +10,11 @@ export const fetchApplications = async ({
   payload: AlbaformApplyPayload;
 }) => {
   try {
-    const response = await instance.post(`/forms/${formId}/applications`, {
+    console.log(payload);
+    const response = await instance.post(
+      `/forms/${formId}/applications`,
       payload,
-    });
+    );
     if (!response.data) {
       throw new Error('지원하기 실패');
     }

--- a/src/lib/fetch/application.ts
+++ b/src/lib/fetch/application.ts
@@ -1,9 +1,18 @@
 import instance from '../api/api';
+import { AlbaformApplyPayload } from '@/app/createAlbaform/types';
 
 // 지원하기
-export const fetchApplications = async (formId: number) => {
+export const fetchApplications = async ({
+  formId,
+  payload,
+}: {
+  formId: number;
+  payload: AlbaformApplyPayload;
+}) => {
   try {
-    const response = await instance.post(`/forms/${formId}/applications`);
+    const response = await instance.post(`/forms/${formId}/applications`, {
+      payload,
+    });
     if (!response.data) {
       throw new Error('지원하기 실패');
     }

--- a/src/lib/fetch/file.ts
+++ b/src/lib/fetch/file.ts
@@ -22,13 +22,25 @@ export const fetchUploadImage = async (file: File) => {
 };
 
 // 이력서 업로드
-export const fetchUploadResume = async () => {
+export const fetchUploadResume = async (
+  file: File,
+): Promise<{ resumeId: number; resumeName: string }> => {
+  const formData = new FormData();
+  formData.append('file', file);
+
   try {
-    const response = await instance.post('/resume/upload');
+    const response = await instance.post('/resume/upload', formData, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    });
     if (!response.data) {
       throw new Error('이력서 업로드 실패');
     }
-    return response.data;
+    return {
+      resumeId: response.data.resumeId,
+      resumeName: response.data.resumeName,
+    };
   } catch (error) {
     console.error('이력서 업로드 중 에러 발생', error);
     throw error;

--- a/src/schemas/albaformApplySchema.ts
+++ b/src/schemas/albaformApplySchema.ts
@@ -9,7 +9,9 @@ export const albaformApplySchema = z.object({
     .refine((val) => !isNaN(Number(val)), {
       message: '숫자만 입력해주세요',
     }),
-  resume: z.string().min(1, '이력서를 추가해주세요'),
+  resume: z.instanceof(File, {message:'이력서를 추가해주세요'}).refine((file) => file.size > 0, {
+    message:'이력서를 추가해주세요'
+  }),
   introduction: z.string().min(1, '자기소개를 입력해주세요'),
 });
 

--- a/src/schemas/albaformApplySchema.ts
+++ b/src/schemas/albaformApplySchema.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+
+export const albaformApplySchema = z.object({
+  name: z.string().min(1, '이름을 입력해주세요'),
+  phoneNumber: z.string().min(1, '연락처를 입력해주세요'),
+  experienceMonths: z
+    .string()
+    .min(1, '경력을 입력해주세요(경력 사항이 없을 시 0으로 표기)')
+    .refine((val) => !isNaN(Number(val)), {
+      message: '숫자만 입력해주세요',
+    }),
+  resume: z.string().min(1, '이력서를 추가해주세요'),
+  introduction: z.string().min(1, '자기소개를 입력해주세요'),
+});
+
+export type AlbaformApplyInput = z.infer<typeof albaformApplySchema>;

--- a/src/stores/useToastStore.ts
+++ b/src/stores/useToastStore.ts
@@ -1,0 +1,15 @@
+import { create } from 'zustand';
+
+interface ToastState {
+  message: string | null;
+  show: boolean;
+  showToast: (message: string) => void;
+  hideToast: () => void;
+}
+
+export const useToastStore = create<ToastState>((set) => ({
+  message: null,
+  show: false,
+  showToast: (message) => set({ message, show: true }),
+  hideToast: () => set({ message: null, show: false }),
+}));


### PR DESCRIPTION
## 🔗 관련 이슈
- Close #X

## 📌 PR 내용 요약
- 지원자 > 알바폼 지원하기 기능 구현, 자세한 내용은 아래의 작업내용에 작성하겠습니다.

## ✨ 작업 내용
- 지원자 > 알바폼 지원하기 페이지 UI/UX
- 지원하기 POST API 전송
- 백엔드 서버에 임시 저장을 할 수 있는 Draft 서버가 별도로 존재하지 않아 유저 아이디와 폼 아이디를 키값으로 사용한 로컬스토리지임시저장 기능 구현
- 알바폼 상세 '지원하기' 버튼 클릭 -> 알바폼 지원하기 페이지로 접근 시 해당 알바폼 id 값 추출을 위한 useSearchParams 사용으로 서버 컴포넌트에서 suspense가 필요하여 layout.ts에 추가
- 글로벌 Toast 생성 및 연동 (지원하기 클릭 후 리스트 페이지로 이동 시 툴팁 출력 등)

## 🔍 테스트 방법 (선택)
<img width="882" alt="스크린샷 2025-06-21 오후 3 14 39" src="https://github.com/user-attachments/assets/f445b00b-a8eb-48bf-a20f-f506f42bb9d7" />

## ⚠️ 참고 및 공유 사항
