### PR TITLE
feat: 미들웨어 추가, owner/applicant 권한에 따라 url 수동 진입 방지

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,9 @@
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
+  experimental: {
+    serverActions: {},
+  },
   compiler: {
     styledComponents: {
       ssr: true,

--- a/src/app/signin/[role]/page.tsx
+++ b/src/app/signin/[role]/page.tsx
@@ -39,6 +39,7 @@ export default function SignIn({
 
   const { mutate, isPending, error } = useSignIn(role, {
     onSuccess: () => {
+      document.cookie = `role=${role}; path=/;`;
       setShowToast(true);
     },
     onError: (err) => {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export const config = {
+  matcher: [
+    '/mypage/owner',
+    '/mypage/owner/:path*',
+    '/mypage/applicant',
+    '/mypage/applicant/:path*',
+    '/createAlbaform/owner',
+    '/createAlbaform/owner/:path*',
+    '/createAlbaform/applicant',
+    '/createAlbaform/applicant/:path*',
+    '/myAlbaform/owner',
+    '/myAlbaform/owner/:path*',
+    '/myAlbaform/applicant',
+    '/myAlbaform/applicant/:path*',
+  ],
+};
+
+export function middleware(req: NextRequest) {
+  const pathname = req.nextUrl.pathname;
+  const role = req.cookies.get('role')?.value;
+
+  if (!role) return NextResponse.next();
+
+  if (pathname.includes('/applicant') && role === 'owner') {
+    return NextResponse.redirect(new URL('/owner', req.url));
+  }
+
+  if (pathname.includes('owner') && role === 'applicant') {
+    return NextResponse.redirect(new URL('/applicant', req.url));
+  }
+
+  return NextResponse.next();
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- Close #X

## 📌 PR 내용 요약
- 미들웨어 추가, owner/applicant 권한에 따라 url 수동 진입 방지

## ✨ 작업 내용
- 로그인 시 토큰에 role(권한) 저장
- middleware.ts에서 토큰에 따른 url 수동 진입 방지 코드 추가

## 🔍 테스트 방법 (선택)
![화면 기록 2025-06-23 오후 3 11 06](https://github.com/user-attachments/assets/a9f480f0-6b14-43de-adc2-9b46b2d9e3e7)

## ⚠️ 참고 및 공유 사항
